### PR TITLE
Update Packit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 result
 .nixos-test-history
-wpia-packit.qcow2
+*.qcow2

--- a/modules/packit-api.nix
+++ b/modules/packit-api.nix
@@ -12,6 +12,10 @@ let
         default = 8080;
         type = types.port;
       };
+      management-port = lib.mkOption {
+        default = 8081;
+        type = types.port;
+      };
       outpackServerUrl = lib.mkOption {
         default = "http://localhost:8000";
         type = types.str;
@@ -86,6 +90,7 @@ in
 
           environment = {
             SERVER_PORT = toString instanceCfg.port;
+            PACKIT_MANAGEMENT_PORT = toString instanceCfg.management-port;
             PACKIT_OUTPACK_SERVER_URL = instanceCfg.outpackServerUrl;
             PACKIT_DB_URL = instanceCfg.database.url;
             PACKIT_DB_USER = instanceCfg.database.user;

--- a/packages/packit/sources.json
+++ b/packages/packit/sources.json
@@ -2,9 +2,9 @@
   "src": {
     "owner": "mrc-ide",
     "repo": "packit",
-    "rev": "3820238e8bfa4d7f4b05c82d525495b4f277b6c4",
-    "hash": "sha256-pmF/2E7JUrP5/ioUUJGzLiFLHpSukaTfDwfJIsSkryk="
+    "rev": "878586c3a4893e6f94064eb95ef91fcc39d27b15",
+    "hash": "sha256-2/08cBy/cilgZHqN2LEMXgOkrdLcsRostEUkZuG7gB8="
   },
-  "gradleDepsHash": "sha256-HTpu1hMNol+Shi2P1GdBnO1oLlqqEWTezdmy4I9ijKY=",
+  "gradleDepsHash": "sha256-FjgjT9AZ8q+qyRGBM7qLVp6Vs9rpPnGPkR3L3AqkklA=",
   "npmDepsHash": "sha256-o//+q3trkCnKpSAWEHPZOeiMYxzKOvrGDgEv63BsnxI="
 }

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -43,12 +43,9 @@ def github_api(path):
     return json.load(urlopen(request))
 
 
-def fetch_latest_commit(owner, repo, branch):
-    if branch is None:
-        branch = github_api(f"/repos/{owner}/{repo}")["default_branch"]
-
-    response = github_api(f"/repos/{owner}/{repo}/git/ref/heads/{branch}")
-    return response["object"]["sha"]
+def resolve_git_ref(owner, repo, ref):
+    response = github_api(f"/repos/{owner}/{repo}/commits/{ref}")
+    return response["sha"]
 
 
 def commit_log(owner, repo, base, head):
@@ -167,7 +164,7 @@ def update(args):
     if args.output is None:
         args.output = os.path.join("packages", args.name, "sources.json")
 
-    rev = fetch_latest_commit(args.owner, args.repo, args.branch)
+    rev = resolve_git_ref(args.owner, args.repo, args.ref)
 
     if metadata["rev"] == rev:
         print(f"{args.name} is already up-to-date at {rev}")
@@ -206,8 +203,9 @@ if __name__ == "__main__":
     parser.add_argument("--owner", help="Owner of source repository.")
     parser.add_argument("--repo", help="Name of source repository.")
     parser.add_argument(
-        "--branch", help="Branch of the source repository to use."
-    )
+        "--ref",
+        help="Git reference (branch name, tag or commit hash)",
+        default="HEAD")
     parser.add_argument("--output", help="File in which to write the result.")
     parser.add_argument(
         "--force",

--- a/vm.nix
+++ b/vm.nix
@@ -12,6 +12,7 @@
     domain = lib.mkForce "localhost:8443";
   };
 
+  networking.hostName = lib.mkForce "wpia-packit-vm";
   users.motd = ''
     Use the 'Ctrl-A x' sequence or the `shutdown now` command to terminate the VM session.
   '';


### PR DESCRIPTION
A bit of tweaks needed to expose the Git revision. By default Nix strips out the `.git` folder. There are ways to keep it, but it tends to be flaky. This replaces the metadata that would have been fetched from git with what we have in the `sources.json`. Works similarly to how we already do it in outpack_server.

The new metrics port needs to be defined, as otherwise all instances were listening on the same port. Metrics are added to in the metrics-proxy, and should get collected by Prometheus automatically.