### PR TITLE
Add a "training" Packit instance.

### DIFF
--- a/services.nix
+++ b/services.nix
@@ -56,7 +56,13 @@
     sslCertificateKey = "/var/secrets/packit.key";
     githubOAuthSecret = "/var/secrets/github-oauth";
 
-    instances = [ "priority-pathogens" "reside" "malariaverse-sitefiles" "kipling" ];
+    instances = [
+      "priority-pathogens"
+      "reside"
+      "malariaverse-sitefiles"
+      "kipling"
+      "training"
+    ];
   };
 
   services.packit-api.instances = {
@@ -104,6 +110,14 @@
         github.org = "malariaverse";
         github.team = "sitefiles";
       };
+    };
+
+    training = {
+      authentication = {
+        method = "github";
+        github.org = "mrc-ide";
+      };
+      defaultRoles = [ "USER" ];
     };
   };
 


### PR DESCRIPTION
The instance is accessible to all members of the mrc-ide organisation. The URL for it will be `https://packit.dide.ic.ac.uk/training`.

To make onboarding of new users as seamless as possible, all new users are granted the `USER` role. Once the instance is deployed I will create the role with general read/write permissions.