### PR TITLE
Import the hardware configuration into the VM.

### DIFF
--- a/PROVISIONING.md
+++ b/PROVISIONING.md
@@ -96,6 +96,12 @@ ssh-keygen -R <fqdn>
     nixos-rebuild switch --flake ".#<hostname>" --target-host root@<fqdn>
     ```
 
+3. The machine is able to reboot and start correctly.
+
+    ```sh
+    ssh root@<fqdn> reboot
+    ```
+
 # Creating a new OAuth token
 
 1. Go to https://github.com/settings/developers

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
         specialArgs = { inherit inputs; };
         modules = [
           ./configuration.nix
+          ./hardware-configuration.nix
           { nixpkgs = pkgsArgs; }
         ];
       };


### PR DESCRIPTION
It's actually kind of important. I guess it must have gotten lost somewhere during the initial setup and went unnoticed until we tried to reboot it.