### PR TITLE
Update packit and outpack_server.

### DIFF
--- a/packages/outpack_server/sources.json
+++ b/packages/outpack_server/sources.json
@@ -2,8 +2,8 @@
   "src": {
     "owner": "mrc-ide",
     "repo": "outpack_server",
-    "rev": "1078d274bc929d73f8c03d28f0c64c72e99e1ab0",
-    "hash": "sha256-jHFCZASFBx0ZVzh+3SKQ0qHcEHwUhShnLQtZA9W51e0="
+    "rev": "d3d2fbd6c549698e7d2a28424d5132144557f159",
+    "hash": "sha256-SBe+uivutwzLENGJkkbSHHVrHzrCPGrnGXGz8Vv05sw="
   },
   "cargoDepsHash": "sha256-9Ab7sYG/0C9x7+9ZPOhtrebVzHYxWeE3KLyeF4HHye0="
 }

--- a/packages/packit/sources.json
+++ b/packages/packit/sources.json
@@ -2,8 +2,8 @@
   "src": {
     "owner": "mrc-ide",
     "repo": "packit",
-    "rev": "6ad0ede011ba084aec7af6dbeb3c10a23da81d3e",
-    "hash": "sha256-mvl3meM1feGXcENGtoh76oQQPtRDEKwAau+67sGnEcg="
+    "rev": "21a8abdba7b4e68b8c15ecadf57d53d1e2c7ad6f",
+    "hash": "sha256-eQUNIV07HoGjnQR9dhqS8cQch7k6h94NJgvUz++EAvI="
   },
   "gradleDepsHash": "sha256-FjgjT9AZ8q+qyRGBM7qLVp6Vs9rpPnGPkR3L3AqkklA=",
   "npmDepsHash": "sha256-o//+q3trkCnKpSAWEHPZOeiMYxzKOvrGDgEv63BsnxI="


### PR DESCRIPTION
Nothing major in the changelog. Couple of minor fixes, and some UI changes in packit.

## outpack_server

- Add custom metadata to /packit/metadata endpoint
- Fix clippy lints on latest Rust.

## packit

- Mrc-5901 Fix Excepion handling packit
- Dont show service user on mange pages
- Mrc 6043 tidy metadata page
- MRC-6053: Log user out when token expired
- Spelling corrections
- Update README.md
- Update README.md
- Change grammatical error
- Rename explorer directory to home