### PR TITLE
Remove a bit of duplication across machines.

### DIFF
--- a/machines/common/base.nix
+++ b/machines/common/base.nix
@@ -1,12 +1,13 @@
+# This file defines the basic configuration for a functional NixOS machine.
+# It won't enable any of packit/outpack/metrics, see `services.nix` for that.
 { self, config, lib, pkgs, self', inputs, ... }: {
   imports = [
-    ./tools.nix
     ../../modules/multi-packit.nix
     ../../modules/vault.nix
     ../../modules/outpack.nix
     ../../modules/packit-api.nix
     ../../modules/metrics-proxy.nix
-    ./services.nix
+    ./tools.nix
     inputs.disko.nixosModules.disko
   ];
 
@@ -33,6 +34,7 @@
     pkgs.gitMinimal
   ];
 
+  services.openssh.enable = true;
   users.users.root.openssh.authorizedKeys.keyFiles = [
     ../../authorized_keys
   ];

--- a/machines/common/services.nix
+++ b/machines/common/services.nix
@@ -1,7 +1,6 @@
 { pkgs, config, inputs, ... }:
 {
   services.nginx.enable = true;
-  services.openssh.enable = true;
   services.postgresql = {
     enable = true;
     ensureUsers = [{
@@ -14,6 +13,23 @@
       host  all      all     127.0.0.1/32   trust
       host  all      all     ::1/128        trust
     '';
+  };
+
+  services.multi-packit = {
+    sslCertificate = "/var/secrets/packit.cert";
+    sslCertificateKey = "/var/secrets/packit.key";
+    githubOAuthSecret = "/var/secrets/github-oauth";
+  };
+
+  vault.secrets = {
+    ssl-certificate.path = "/var/secrets/packit.cert";
+    ssl-key.path = "/var/secrets/packit.key";
+    github-oauth = {
+      path = "/var/secrets/github-oauth";
+      fields.PACKIT_GITHUB_CLIENT_ID = "clientId";
+      fields.PACKIT_GITHUB_CLIENT_SECRET = "clientSecret";
+      format = "env";
+    };
   };
 
   services.metrics-proxy = {

--- a/machines/default.nix
+++ b/machines/default.nix
@@ -4,21 +4,13 @@ let inherit (inputs.nixpkgs.lib) nixosSystem; in
   flake.nixosConfigurations = {
     wpia-packit = withSystem "x86_64-linux" ({ pkgs, system, self', ... }: nixosSystem {
       specialArgs = { inherit inputs self'; };
-      modules = [
-        ./wpia-packit.nix
-        ./common/hardware-configuration.nix
-        ./common/disk-config.nix
-      ];
+      modules = [ ./wpia-packit.nix ];
       inherit system pkgs;
     });
 
     wpia-packit-private = withSystem "x86_64-linux" ({ pkgs, system, self', ... }: nixosSystem {
       specialArgs = { inherit inputs self'; };
-      modules = [
-        ./wpia-packit-private.nix
-        ./common/hardware-configuration.nix
-        ./common/disk-config.nix
-      ];
+      modules = [ ./wpia-packit-private.nix ];
       inherit system pkgs;
     });
   };

--- a/machines/wpia-packit-private.nix
+++ b/machines/wpia-packit-private.nix
@@ -1,39 +1,23 @@
-{ pkgs, config, lib, ... }: {
+{
   imports = [
-    ./common/configuration.nix
+    ./common/hardware-configuration.nix
+    ./common/disk-config.nix
+    ./common/base.nix
+    ./common/services.nix
   ];
 
   networking.hostName = "wpia-packit-private";
 
-  vault.secrets = [
-    {
-      key = "packit/ssl/private/cert";
-      path = "/var/secrets/packit.cert";
-    }
-    {
-      key = "packit/ssl/private/key";
-      path = "/var/secrets/packit.key";
-    }
-    {
-      key = "packit/oauth/private";
-      path = "/var/secrets/github-oauth";
-      fields.PACKIT_GITHUB_CLIENT_ID = "clientId";
-      fields.PACKIT_GITHUB_CLIENT_SECRET = "clientSecret";
-      format = "env";
-    }
-  ];
-
   services.multi-packit = {
     enable = true;
     domain = "packit-private.dide.ic.ac.uk";
+    instances = [ "kipling" ];
+  };
 
-    sslCertificate = "/var/secrets/packit.cert";
-    sslCertificateKey = "/var/secrets/packit.key";
-    githubOAuthSecret = "/var/secrets/github-oauth";
-
-    instances = [
-      "kipling"
-    ];
+  vault.secrets = {
+    "ssl-certificate".key = "packit/ssl/private/cert";
+    "ssl-key".key = "packit/ssl/private/key";
+    "github-oauth".key = "packit/oauth/private";
   };
 
   services.packit-api.instances = {

--- a/machines/wpia-packit.nix
+++ b/machines/wpia-packit.nix
@@ -1,37 +1,22 @@
-{ pkgs, config, lib, self, ... }:
 {
   imports = [
-    ./common/configuration.nix
+    ./common/hardware-configuration.nix
+    ./common/disk-config.nix
+    ./common/base.nix
+    ./common/services.nix
   ];
 
   networking.hostName = "wpia-packit";
 
-  vault.secrets = [
-    {
-      key = "packit/ssl/production/cert";
-      path = "/var/secrets/packit.cert";
-    }
-    {
-      key = "packit/ssl/production/key";
-      path = "/var/secrets/packit.key";
-    }
-    {
-      key = "packit/oauth/production";
-      path = "/var/secrets/github-oauth";
-      fields.PACKIT_GITHUB_CLIENT_ID = "clientId";
-      fields.PACKIT_GITHUB_CLIENT_SECRET = "clientSecret";
-      format = "env";
-    }
-  ];
+  vault.secrets = {
+    "ssl-certificate".key = "packit/ssl/production/cert";
+    "ssl-key".key = "packit/ssl/production/key";
+    "github-oauth".key = "packit/oauth/production";
+  };
 
   services.multi-packit = {
     enable = true;
     domain = "packit.dide.ic.ac.uk";
-
-    sslCertificate = "/var/secrets/packit.cert";
-    sslCertificateKey = "/var/secrets/packit.key";
-    githubOAuthSecret = "/var/secrets/github-oauth";
-
     instances = [
       "priority-pathogens"
       "reside"

--- a/modules/vault.nix
+++ b/modules/vault.nix
@@ -55,7 +55,7 @@ in
       };
 
       secrets = lib.mkOption {
-        type = lib.types.listOf (lib.types.submodule secretModule);
+        type = lib.types.attrsOf (lib.types.submodule secretModule);
       };
 
       spec = lib.mkOption {

--- a/scripts/fetch-secrets.py
+++ b/scripts/fetch-secrets.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         client.token = login_response["auth"]["client_token"]
 
     spec = json.load(args.spec)
-    for entry in spec:
+    for entry in spec.values():
         path = args.root.joinpath(Path(entry["path"]).relative_to("/"))
         print(f"Reading {entry['mount']}/{entry['key']} to {path}")
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/default.nix
+++ b/tests/integration/default.nix
@@ -5,7 +5,7 @@ pkgs.testers.runNixOSTest {
   node.specialArgs = specialArgs;
   nodes.machine = { lib, config, ... }: {
     imports = [
-      ../../machines/common/configuration.nix
+      ../../machines/common/base.nix
       ../../machines/common/services.nix
 
       # The `virtualisation.vmVariant` setting we use to import VM-specific

--- a/vm.nix
+++ b/vm.nix
@@ -6,21 +6,22 @@
     host.port = 8443;
     guest.port = 443;
   }];
-  virtualisation.qemu.options = [ "-nographic" ];
+  virtualisation.graphics = false;
 
   services.multi-packit = {
     domain = lib.mkForce "localhost:8443";
   };
 
-  vault.secrets = lib.mkForce [{
-    key = "packit/githubauth/auth/githubclient";
-    path = "/var/secrets/github-oauth";
-    fields.PACKIT_GITHUB_CLIENT_ID = "id";
-    fields.PACKIT_GITHUB_CLIENT_SECRET = "secret";
-    format = "env";
-  }];
+  vault.secrets = lib.mkForce {
+    github-oauth = {
+      key = "packit/githubauth/auth/githubclient";
+      path = "/var/secrets/github-oauth";
+      fields.PACKIT_GITHUB_CLIENT_ID = "id";
+      fields.PACKIT_GITHUB_CLIENT_SECRET = "secret";
+      format = "env";
+    };
+  };
 
-  networking.hostName = lib.mkForce "wpia-packit-vm";
   users.motd = ''
     Server is available at https://${config.services.multi-packit.domain}.
     Use the 'Ctrl-A x' sequence or the `shutdown now` command to terminate the VM session.


### PR DESCRIPTION
A few bits were repeated across the two machine definitions, in particular the Vault secrets configuration. We can remove that duplication by moving the common parts into the `common/` directory.

The parts that differ by machine, ie. the path to the secret within Vault, is left in the machine specific file. To make the split easier, the list of secrets is turned into an attribute, allowing the same secret to be referenced across files.