### PR TITLE
Automatically deploy from GitHub branches.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "comin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731534082,
+        "narHash": "sha256-n8yVzBixxaj0Qn6SV655t6QUtKSOJ+sR4AEoq0Vqb/0=",
+        "owner": "nlewo",
+        "repo": "comin",
+        "rev": "9afca855518f79b5bff3d2a9663b2e6f81dd361a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "comin",
+        "type": "github"
+      }
+    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -68,6 +88,7 @@
     },
     "root": {
       "inputs": {
+        "comin": "comin",
         "disko": "disko",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,8 @@
   inputs.disko.url = "github:nix-community/disko";
   inputs.disko.inputs.nixpkgs.follows = "nixpkgs";
   inputs.flake-parts.url = "github:hercules-ci/flake-parts";
+  inputs.comin.url = "github:nlewo/comin";
+  inputs.comin.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, lib, self, nixpkgs, ... }: {
     imports = [

--- a/machines/common/autodeploy.nix
+++ b/machines/common/autodeploy.nix
@@ -1,0 +1,14 @@
+{ config, ... }: {
+  services.comin = {
+    enable = true;
+    remotes = [{
+      name = "origin";
+      url = "https://github.com/reside-ic/packit-infra";
+
+      branches.main.name = "deploy/${config.networking.hostName}";
+      # We don't use testing branches - we manage test environments through
+      # GitHub.
+      branches.testing.name = "";
+    }];
+  };
+}

--- a/machines/common/base.nix
+++ b/machines/common/base.nix
@@ -9,6 +9,7 @@
     ../../modules/metrics-proxy.nix
     ./tools.nix
     inputs.disko.nixosModules.disko
+    inputs.comin.nixosModules.comin
   ];
 
   virtualisation.vmVariant = {

--- a/machines/common/services.nix
+++ b/machines/common/services.nix
@@ -39,6 +39,10 @@
       upstream = "http://localhost:${toString config.services.prometheus.exporters.node.port}/metrics";
       labels.job = "machine-metrics";
     };
+    endpoints."comin" = lib.mkIf config.services.comin.enable {
+      upstream = "http://localhost:${toString config.services.comin.exporter.port}/metrics";
+      labels.job = "comin";
+    };
   };
 
   environment.etc."metrics/static-metrics.prom".text =

--- a/machines/wpia-packit-dev.nix
+++ b/machines/wpia-packit-dev.nix
@@ -5,6 +5,7 @@
     ./common/disk-config.nix
     ./common/base.nix
     ./common/services.nix
+    ./common/autodeploy.nix
   ];
 
   networking.hostName = "wpia-packit-dev";

--- a/vm.nix
+++ b/vm.nix
@@ -58,4 +58,8 @@
     };
 
   services.getty.autologinUser = "root";
+
+  # Disable auto-deploy of local VMs, this would be pretty surprising and
+  # hinder local development.
+  services.comin.enable = lib.mkForce false;
 }


### PR DESCRIPTION
The machines each have a dedicated branch, named `deploy/<hostname>`. They periodically pull the configuration from that branch and deploy it.

Separately, we will add a process for managing this branch using GitHub action. A likely flow will be to synchronize the deploy branches to main by default, but target it to feature branches when a label is applied to a pull request.

For now this is only enabled for wpia-packit-dev. Once I get a bit more experience with it and am happy with the workflow we will consider using it on the production machines.