### PR TITLE
Remove ICT scan configuration code

### DIFF
--- a/machines/common/configuration.nix
+++ b/machines/common/configuration.nix
@@ -37,11 +37,6 @@
     ../../authorized_keys
   ];
 
-  users.users.vscan-dide = {
-    isNormalUser = true;
-    openssh.authorizedKeys.keys = [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDG/MCRfHKu4trSoii5eeozpZlOQJ5t8YwowTBy5q5rDCUr/pcZNFmfzEfeTerOV2ON8CiAfx/LADCJFRNRvSiMawGqF6U3Xstk/JTh6IXbowukhdKqpqom/BF2Oryy6iDFlnUTX3wJJGdsV/9DnSBzudngsmSMOFs8aFbVKrQ3V6mI7itq2+Qfg4a428uU1912TG2n9SnEYTnufYtPIivz+Kx/3YP5o5u2YW9FgZJlp502ce4harols28wsmVd2jZ9yrlRGlQSyuRnSf45PKiVdv4CEhCb7ppSrE7u0lGnhT2uENm+jpHoJ4/CSxtrUgQFDCqJarQuipojhPurRqEXT+NX6wjgqOXof2ouBrVKvJ3NoSCuMAltPxDazC+UELy0y67uiAq5APnwzny7w+VxkbBz3b1tetI9igZ13AjhVu0R4SeSHjb/TZkYdx+kUHEzLzv1NgzeGCVY7NKjTOFnqqneIQIeOwW/0bxQ9FoPsz/u3D3OYwyjnhNG9GUySHk= ic/elton@icsecwop2" ];
-  };
-
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Keep derivations when garbage collecting the Nix store. We use these

--- a/machines/common/services.nix
+++ b/machines/common/services.nix
@@ -1,21 +1,7 @@
-{ pkgs, config, lib, inputs, ... }:
+{ pkgs, config, inputs, ... }:
 {
   services.nginx.enable = true;
   services.openssh.enable = true;
-  services.openssh.settings.HostKeyAlgorithms = lib.concatStringsSep "," [
-    "rsa-sha2-512"
-    "rsa-sha2-256"
-    "ssh-ed25519"
-    "ssh-rsa" # For ICT
-  ];
-  services.openssh.settings.Macs = [
-    "hmac-sha2-512-etm@openssh.com"
-    "hmac-sha2-256-etm@openssh.com"
-    "umac-128-etm@openssh.com"
-    "hmac-sha2-256" # For ICT
-    "hmac-sha2-512" # For ICT
-  ];
-
   services.postgresql = {
     enable = true;
     ensureUsers = [{


### PR DESCRIPTION
When we opened up packit to public traffic, we added a few configuration options to allow ICT's scanner to poke around the VM. Now that this process is done, we can revert those changes.