### PR TITLE
Simplify the churn caused by the static metrics.

### DIFF
--- a/machines/common/services.nix
+++ b/machines/common/services.nix
@@ -39,20 +39,21 @@
     };
   };
 
+  environment.etc."metrics/static-metrics.prom".text =
+    let
+      inherit (inputs) self;
+      rev = self.rev or self.dirtyRev or "unknown";
+    in
+    ''
+      nixos_configuration_info{revision="${rev}"} 1
+    '';
+
   services.prometheus.exporters = {
-    node =
-      let
-        inherit (inputs) self;
-        rev = self.rev or self.dirtyRev or "unknown";
-        staticMetrics = pkgs.writeTextDir "static-metrics.prom" ''
-          nixos_configuration_info{revision="${rev}", flake_hash="${self.narHash}"} 1
-        '';
-      in
-      {
-        enable = true;
-        enabledCollectors = [ "systemd" "textfile" ];
-        extraFlags = [ "--collector.textfile.directory=${staticMetrics}" ];
-        port = 9001;
-      };
+    node = {
+      enable = true;
+      enabledCollectors = [ "systemd" "textfile" ];
+      extraFlags = [ "--collector.textfile.directory=/etc/metrics" ];
+      port = 9001;
+    };
   };
 }


### PR DESCRIPTION
We have a metric that reports the revision of the configuration, and its hash. The latter causes a lot of churn any time any character is changed, and probably does not add a lot of value. The Git revision is useful enough on its own.

Additionally, the metric changes on every deployment, which was causing the node exporter to restart. We can avoid that by adding a level of indirection, by making the node exporter scan a directory in `/etc`, and populate that directory instead. The exporter will pick up new versions of the file without needing to restart.