### PR TITLE
Add a GitHub workflow to update outpack_server and packit.

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,105 @@
+# This workflow runs nightly and pulls in new version of packit and
+# outpack_server into this repository, by running the `scripts/update.py`
+# script.
+#
+# If any updates are found, a pull request is created with the changes. If an
+# open pull request already exists, it is updated instead.
+#
+# In addition to running automatically, this workflow may be triggered
+# manually. When doing so, one may specify a particular Git ref to update
+# either package to.
+#
+# Using the `gh` command-line tool, assuming mrc-1234 is a valid branch on the
+# mrc-ide/packit repository:
+#
+# ```
+# gh workflow run -R reside-ic/packit-infra update.yaml -f packit=mrc-1234
+# ```
+
+name: Update packages
+on:
+  schedule:
+    - cron: '0 0 * * *' # Daily at midnight UTC
+
+  workflow_dispatch:
+    inputs:
+      outpack_server:
+        description: 'Git ref from which to update outpack_server'
+        type: string
+        required: true
+        default: 'HEAD'
+
+      packit:
+        description: 'Git ref from which to update packit'
+        type: string
+        required: true
+        default: 'HEAD'
+
+jobs:
+  update:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Update outpack_server
+        run: nix run .#update outpack_server -- --ref ${{ inputs.outpack_server }} --write-commit-log ${{ runner.temp }}/outpack_server.md
+      - name: Update packit
+        run: nix run .#update packit -- --ref ${{ inputs.packit }} --write-commit-log ${{ runner.temp }}/packit.md
+
+      - name: Prepare PR message
+        uses: actions/github-script@v7
+        id: prepare-message
+        with:
+          script: |
+            const fs = require("fs");
+            const lf = new Intl.ListFormat('en');
+
+            var packages = [];
+            var message = "";
+            for (const p of ["outpack_server", "packit"]) {
+              if (fs.existsSync(`${process.env.RUNNER_TEMP}/${p}.md`)) {
+                var sources = JSON.parse(fs.readFileSync(`packages/${p}/sources.json`));
+                message += `# Updating ${p} to ${sources.src.rev}\n`;
+                message += fs.readFileSync(`${process.env.RUNNER_TEMP}/${p}.md`);
+                packages.push(p);
+              }
+            }
+            core.setOutput('title', "Update " + lf.format(packages));
+            core.setOutput('body', message);
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        id: create-pr
+        with:
+          branch: actions/update-packages
+          title: ${{ steps.prepare-message.outputs.title }}
+          body: ${{ steps.prepare-message.outputs.body }}
+          commit-message: |
+            ${{ steps.prepare-message.outputs.title }}
+
+            ${{ steps.prepare-message.outputs.body }}
+          reviewers: plietar
+
+      - name: Comment hint
+        uses: thollander/actions-comment-pull-request@v3
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        with:
+          pr-number: ${{ steps.create-pr.outputs.pull-request-number }}
+          message: |
+            You can deploy this pull request by running the following command:
+
+            ```sh
+            nix run "github:${{ github.repository }}?ref=refs/pull/${{ steps.create-pr.outputs.pull-request-number }}/merge#deploy" <hostname>
+            ```
+
+            After merging this pull request, you must deploy the ${{ github.event.repository.default_branch }} branch to each host by running the following command:
+
+            ```sh
+            nix run "github:${{ github.repository }}#deploy" <hostname>
+            ```

--- a/README.md
+++ b/README.md
@@ -25,18 +25,25 @@ Where `<hostname>` is replaced by `wpia-packit` or `wpia-packit-private`.
 
 ### How do I update outpack_server or Packit?
 
+The Git revision of outpack_server and packit is pinned in JSON files found in
+the [`packages/` directory](packages). These files also locks the packages'
+dependencies.
+
+A [GitHub actions workflow](.github/workflows/update.yaml) runs nightly and
+creates (or updates) a pull request to update outpack_server and Packit to
+their latest revision. If necessary, the workflow can also be triggered
+manually, in which case an alternative branch may be specified.
+
+After merging the pull request created by the workflow, you should re-deploy to
+all hosts following the instructions above.
+
+Equivalently, you may update the versions manually yourself by running either
+of the following commands:
+
 ```
-nix run .#update packit
 nix run .#update outpack_server
+nix run .#update packit
 ```
-
-The sources are defined in files at `packages/{packit,outpack_server}/source.json`.
-The update script automatically fetches the latest revision from GitHub, and
-updates the necessary hashes.
-
-It also accepts a `--branch` argument which may be used to specify a branch
-name. Otherwise the default branch of the repository will be used (usually main
-or master).
 
 ### How do I build the deployment?
 

--- a/playbooks/new-machine-provisioning.md
+++ b/playbooks/new-machine-provisioning.md
@@ -126,6 +126,17 @@ ssh-keygen -R <fqdn>
     ssh root@<fqdn>
     ```
 
+## Add the machine to Prometheus
+
+The prometheus instance running on `bots.dide.ic.ac.uk` needs to be made aware
+of your newly created Packit host.
+
+Modify [the `packit` scrape rules in `prometheus.yml`](prometheus.yml) to add
+the new hostname. Individual services and Packit instances running on the host
+are discovered automatically.
+
+[prometheus.yml]: https://github.com/vimc/montagu-monitor/blob/7370692/config/prometheus/prometheus.yml#L127-L135
+
 # Creating a new OAuth Application
 
 Packit needs a GitHub OAuth application to function. Each application can only


### PR DESCRIPTION
This runs the existing `nix run .#update <package>` commands, and if an update is found it creates a pull request against the repository. By default the packages are updated to main, although one can run the workflow manually and override the branch name for each package.