### PR TITLE
Fix update workflow.

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -26,14 +26,10 @@ on:
       outpack_server:
         description: 'Git ref from which to update outpack_server'
         type: string
-        required: true
-        default: 'HEAD'
 
       packit:
         description: 'Git ref from which to update packit'
         type: string
-        required: true
-        default: 'HEAD'
 
 jobs:
   update:
@@ -48,9 +44,9 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Update outpack_server
-        run: nix run .#update outpack_server -- --ref ${{ inputs.outpack_server }} --write-commit-log ${{ runner.temp }}/outpack_server.md
+        run: nix run .#update outpack_server -- --ref ${{ inputs.outpack_server || 'HEAD' }} --write-commit-log ${{ runner.temp }}/outpack_server.md
       - name: Update packit
-        run: nix run .#update packit -- --ref ${{ inputs.packit }} --write-commit-log ${{ runner.temp }}/packit.md
+        run: nix run .#update packit -- --ref ${{ inputs.packit || 'HEAD' }} --write-commit-log ${{ runner.temp }}/packit.md
 
       - name: Prepare PR message
         uses: actions/github-script@v7


### PR DESCRIPTION
When the workflow runs on schedule, as opposed to being manually triggered, the inputs are empty. We need to provide defaults at the use site, since the ones from the workflow_dipspatch do not get applied.