### PR TITLE
Use 127.0.0.1 instead of localhost.

### DIFF
--- a/machines/common/services.nix
+++ b/machines/common/services.nix
@@ -36,7 +36,7 @@
     enable = true;
     domain = config.services.multi-packit.domain;
     endpoints."node_exporter" = {
-      upstream = "http://localhost:${toString config.services.prometheus.exporters.node.port}/metrics";
+      upstream = "http://127.0.0.1:${toString config.services.prometheus.exporters.node.port}/metrics";
       labels.job = "machine-metrics";
     };
   };

--- a/modules/multi-packit.nix
+++ b/modules/multi-packit.nix
@@ -73,15 +73,19 @@ in
         management-port = ports."${name}".packit-api-management;
 
         apiRoot = "https://${cfg.domain}/${name}/packit/api";
-        outpackServerUrl = "http://localhost:${toString ports."${name}".outpack}";
+        outpackServerUrl = "http://127.0.0.1:${toString ports."${name}".outpack}";
         authentication = {
           github.redirect_url = "https://${cfg.domain}/${name}/redirect";
           service.audience = lib.mkIf (builtins.length config.authentication.service.policies > 0) "https://${cfg.domain}/${name}";
         };
         corsAllowedOrigins = [ "https://${cfg.domain}" ];
-        database.url = "jdbc:postgresql://localhost:5432/${name}?stringtype=unspecified";
-        database.user = name;
-        database.password = name;
+
+        database = {
+          url = "jdbc:postgresql://127.0.0.1:5432/${name}?stringtype=unspecified";
+          user = name;
+          password = name;
+        };
+
         environmentFiles = [
           "/var/secrets/packit/${name}/jwt-key"
         ] ++ lib.optionals (config.authentication.method == "github") [
@@ -134,21 +138,21 @@ in
 
         "^~ /${name}/packit/api/" = {
           priority = 999;
-          proxyPass = "http://localhost:${toString ports."${name}".packit-api}/";
+          proxyPass = "http://127.0.0.1:${toString ports."${name}".packit-api}/";
         };
       });
     };
 
     services.metrics-proxy.endpoints = foreachInstance (name: {
       "packit-api/${name}" = {
-        upstream = "http://localhost:${toString ports."${name}".packit-api-management}/prometheus";
+        upstream = "http://127.0.0.1:${toString ports."${name}".packit-api-management}/prometheus";
         labels = {
           job = "packit-api";
           project = name;
         };
       };
       "outpack_server/${name}" = {
-        upstream = "http://localhost:${toString ports."${name}".outpack}/metrics";
+        upstream = "http://127.0.0.1:${toString ports."${name}".outpack}/metrics";
         labels = {
           job = "outpack_server";
           project = name;

--- a/modules/packit-api.nix
+++ b/modules/packit-api.nix
@@ -59,7 +59,7 @@ let
         type = types.port;
       };
       outpackServerUrl = lib.mkOption {
-        default = "http://localhost:8000";
+        default = "http://127.0.0.1:8000";
         type = types.str;
       };
 


### PR DESCRIPTION
By default, nginx was trying to contact outpack_server over IPv6, but outpack_server does not support this (it only listens on one address). While nginx would then fallback to IPv4 and succeed, this caused a lot of log noise.

Using 127.0.0.1 throughout should prevent this.