### PR TITLE
Make the helper scripts hermetic.

### DIFF
--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -1,39 +1,72 @@
 { self, ... }:
 {
-  perSystem = { pkgs, lib, ... }: {
-    packages = {
-      fetch-secrets = pkgs.writers.writePython3Bin "fetch-secrets"
-        {
-          libraries = [ pkgs.python3.pkgs.hvac ];
-        } ./fetch-secrets.py;
+  perSystem = { pkgs, lib, ... }:
+    let
+      # These capture the derivation (but not the output) of each machine's
+      # configuration. The scripts that use these (eg. deploy/diff/start-vm)
+      # are responsible for turning the drv into the final product when it is
+      # needed.
+      #
+      # nix has a weird quirk that makes `drvPath` depend on all the input
+      # sources recursively, even those not needed to build thanks to binary
+      # caches. While scary sounding, `unsafeDiscardOutputDependency` works
+      # well in this case to avoid that particular issue. There does seem to be
+      # a plan to fix this eventually: https://github.com/NixOS/nix/issues/7910
+      nixosDerivations = lib.mapAttrs
+        (_: v: {
+          fqdn = v.config.networking.fqdn;
+          drvPath = builtins.unsafeDiscardOutputDependency v.config.system.build.toplevel.drvPath;
+        })
+        self.nixosConfigurations;
+
+      vmDerivations = lib.mapAttrs
+        (_: v: {
+          vaultUrl = v.config.vault.url;
+          drvPath = builtins.unsafeDiscardOutputDependency v.config.system.build.vm.drvPath;
+          mainProgram = v.config.system.build.vm.meta.mainProgram;
+        })
+        self.nixosConfigurations;
+
+      NIXOS_CONFIGURATIONS = pkgs.writers.writeJSON "hosts.json" nixosDerivations;
+      VM_CONFIGURATIONS = pkgs.writers.writeJSON "hosts.json" vmDerivations;
+    in
+    {
+      packages = {
+        fetch-secrets = pkgs.writers.writePython3Bin "fetch-secrets"
+          {
+            libraries = [ pkgs.python3.pkgs.hvac ];
+          } ./fetch-secrets.py;
+      };
+
+      apps = {
+        update.program = pkgs.writers.writePython3Bin "update" { } ./update.py;
+
+        update-ssh-keys.program = pkgs.writeShellApplication {
+          name = "update-ssh-keys";
+          runtimeInputs = [ pkgs.curl ];
+          text = builtins.readFile ./update-ssh-keys.sh;
+        };
+
+        deploy.program = pkgs.writeShellApplication {
+          name = "deploy";
+          text = builtins.readFile ./deploy.sh;
+          runtimeInputs = [ pkgs.jq pkgs.nix pkgs.openssh ];
+          runtimeEnv = { inherit NIXOS_CONFIGURATIONS; };
+        };
+
+        diff.program = pkgs.writeShellApplication {
+          name = "diff";
+          text = builtins.readFile ./diff.sh;
+          runtimeInputs = [ pkgs.jq pkgs.nix pkgs.nix-diff pkgs.openssh ];
+          runtimeEnv = { inherit NIXOS_CONFIGURATIONS; };
+        };
+
+        start-vm.program = pkgs.writeShellApplication {
+          name = "start-vm";
+          text = builtins.readFile ./start-vm.sh;
+          runtimeInputs = [ pkgs.jq pkgs.nix pkgs.vault-bin ];
+          runtimeEnv = { inherit VM_CONFIGURATIONS; };
+        };
+      };
     };
-
-    apps = {
-      update.program = pkgs.writers.writePython3Bin "update" { } ./update.py;
-
-      update-ssh-keys.program = pkgs.writeShellApplication {
-        name = "update-ssh-keys";
-        runtimeInputs = [ pkgs.curl ];
-        text = builtins.readFile ./update-ssh-keys.sh;
-      };
-
-      deploy.program = pkgs.writeShellApplication {
-        name = "deploy";
-        runtimeInputs = [ pkgs.nix pkgs.openssh ];
-        text = builtins.readFile ./deploy.sh;
-      };
-
-      start-vm.program = pkgs.writeShellApplication {
-        name = "start-vm";
-        runtimeInputs = [ pkgs.vault-bin ];
-        text = builtins.readFile ./start-vm.sh;
-      };
-
-      diff.program = pkgs.writeShellApplication {
-        name = "diff";
-        runtimeInputs = [ pkgs.nix pkgs.openssh pkgs.nix-diff ];
-        text = builtins.readFile ./diff.sh;
-      };
-    };
-  };
 }


### PR DESCRIPTION
We have a handful of scripts that operate on the NixOS host configurations, for deploying / comparing / running in a VM.

These scripts take in a hostname and build the system configuration for that host. Previously the scripts did this by invoking `nix build .#nixosConfiguration.<hostname>....` (or equivalent), assuming that the command was run from within the repository.

This worked well if the user ran `nix run .#deploy <hostname>`, but doesn't work so well if the user instead uses an arbitrary flake reference to run the script, such as with
`nix run github:reside-ic/packit-infra#deploy <hostname>`. Instead of using the system configuration from GitHub, this command would look for it in the current working directory.

To make this pattern work better, the scripts are modified to embed a path to the pre-evaluated system configurations. With this data made available to the helpers scripts, they can run hermetically without needing to evaluate the flake a second time.

The system configurations are only pre-evaluated, not pre-built. This distinction is important since we don't want to have to build the configuration for all hosts just to deploy a single one.