### PR TITLE
Mrc-6218 - Add orderly runners

### DIFF
--- a/machines/common/base.nix
+++ b/machines/common/base.nix
@@ -6,6 +6,7 @@
     ../../modules/vault.nix
     ../../modules/outpack.nix
     ../../modules/packit-api.nix
+    ../../modules/orderly-runner.nix
     ../../modules/metrics-proxy.nix
     ./tools.nix
     inputs.disko.nixosModules.disko

--- a/machines/wpia-packit-dev.nix
+++ b/machines/wpia-packit-dev.nix
@@ -25,9 +25,8 @@
         method = "github";
         github.org = "reside-ic";
       };
+      runner.repositoryUrl = "https://github.com/mrc-ide/packit-infra-test-repo.git";
     };
-
-    runner.repositoryUrl = "https://github.com/mrc-ide/packit-infra-test-repo.git";
   };
 
   services.orderly-runner = {

--- a/machines/wpia-packit-dev.nix
+++ b/machines/wpia-packit-dev.nix
@@ -29,4 +29,9 @@
 
     runner.repositoryUrl = "https://github.com/mrc-ide/packit-infra-test-repo.git";
   };
+
+  services.orderly-runner = {
+    enable = true;
+    workers = 1;
+  };
 }

--- a/machines/wpia-packit-dev.nix
+++ b/machines/wpia-packit-dev.nix
@@ -25,7 +25,10 @@
         method = "github";
         github.org = "reside-ic";
       };
-      runner.repositoryUrl = "https://github.com/reside-ic/packit-infra-test-repo.git";
+      runner = {
+        enable = true;
+        repositoryUrl = "https://github.com/reside-ic/packit-infra-test-repo.git";
+      };
     };
   };
 

--- a/machines/wpia-packit-dev.nix
+++ b/machines/wpia-packit-dev.nix
@@ -25,7 +25,7 @@
         method = "github";
         github.org = "reside-ic";
       };
-      runner.repositoryUrl = "https://github.com/mrc-ide/packit-infra-test-repo.git";
+      runner.repositoryUrl = "https://github.com/reside-ic/packit-infra-test-repo.git";
     };
   };
 

--- a/machines/wpia-packit-dev.nix
+++ b/machines/wpia-packit-dev.nix
@@ -1,4 +1,3 @@
-{ pkgs, config, lib, self, ... }:
 {
   imports = [
     ./common/hardware-configuration.nix
@@ -27,5 +26,7 @@
         github.org = "reside-ic";
       };
     };
+
+    runner.repositoryUrl = "https://github.com/mrc-ide/packit-infra-test-repo.git";
   };
 }

--- a/machines/wpia-packit.nix
+++ b/machines/wpia-packit.nix
@@ -18,9 +18,9 @@
     enable = true;
     domain = "packit.dide.ic.ac.uk";
     instances = [
-      # "priority-pathogens"
+      "priority-pathogens"
       "reside"
-      # "malariaverse-sitefiles"
+      "malariaverse-sitefiles"
       "training"
     ];
   };

--- a/machines/wpia-packit.nix
+++ b/machines/wpia-packit.nix
@@ -53,7 +53,10 @@
         }];
       };
 
-      runner.repositoryUrl = "https://github.com/reside-ic/packit-infra-test-repo.git";
+      runner = {
+        enable = true;
+        repositoryUrl = "https://github.com/reside-ic/packit-infra-test-repo.git";
+      };
     };
 
     malariaverse-sitefiles = {

--- a/machines/wpia-packit.nix
+++ b/machines/wpia-packit.nix
@@ -18,9 +18,9 @@
     enable = true;
     domain = "packit.dide.ic.ac.uk";
     instances = [
-      "priority-pathogens"
+      # "priority-pathogens"
       "reside"
-      "malariaverse-sitefiles"
+      # "malariaverse-sitefiles"
       "training"
     ];
   };

--- a/machines/wpia-packit.nix
+++ b/machines/wpia-packit.nix
@@ -53,7 +53,7 @@
         }];
       };
 
-      runner.repositoryUrl = "https://github.com/mrc-ide/packit-infra-test-repo.git";
+      runner.repositoryUrl = "https://github.com/reside-ic/packit-infra-test-repo.git";
     };
 
     malariaverse-sitefiles = {

--- a/machines/wpia-packit.nix
+++ b/machines/wpia-packit.nix
@@ -52,6 +52,8 @@
           grantedPermissions = [ "outpack.read" "outpack.write" ];
         }];
       };
+
+      runner.repositoryUrl = "https://github.com/mrc-ide/packit-infra-test-repo.git";
     };
 
     malariaverse-sitefiles = {
@@ -70,5 +72,10 @@
       };
       defaultRoles = [ "USER" ];
     };
+  };
+
+  services.orderly-runner = {
+    enable = true;
+    workers = 4;
   };
 }

--- a/modules/multi-packit.nix
+++ b/modules/multi-packit.nix
@@ -76,7 +76,7 @@ in
 
         apiRoot = "https://${cfg.domain}/${name}/packit/api";
         outpackServerUrl = "http://127.0.0.1:${toString ports."${name}".outpack}";
-        orderlyRunnerApiUrl = "http://127.0.0.1:${toString config.services.orderly-runner.port}";
+        orderlyRunnerApiUrl = "http://127.0.0.1:${toString orderlyRunnerCfg.port}";
         authentication = {
           github.redirect_url = "https://${cfg.domain}/${name}/redirect";
           service.audience = lib.mkIf (builtins.length config.authentication.service.policies > 0) "https://${cfg.domain}/${name}";

--- a/modules/multi-packit.nix
+++ b/modules/multi-packit.nix
@@ -3,6 +3,7 @@ let
   inherit (lib) types;
 
   cfg = config.services.multi-packit;
+  orderlyRunnerCfg = config.services.orderly-runner;
   foreachInstance = f: lib.mkMerge (lib.map f cfg.instances);
 
   landingPage = pkgs.runCommand "packit-index"
@@ -94,6 +95,12 @@ in
           cfg.githubOAuthSecret
         ];
         properties."java.io.tmpdir" = "/var/tmp";
+
+        # force disable if repositoryUrl not provided otherwise default to
+        # orderly runner enable value
+        runner.enable = if (!(config.runner ? repositoryUrl))
+          then lib.mkForce false
+          else lib.mkDefault orderlyRunnerCfg.enable;
       });
     });
 

--- a/modules/multi-packit.nix
+++ b/modules/multi-packit.nix
@@ -27,7 +27,7 @@ let
       packit-api = 8080 + idx;
       packit-api-management = 8160 + idx;
     })
-    cfg.instances) // { orderly-runner-api = config.services.orderly-runner.port; }; # 8240 by default
+    cfg.instances);
 in
 {
   options.services.multi-packit = {
@@ -76,7 +76,7 @@ in
 
         apiRoot = "https://${cfg.domain}/${name}/packit/api";
         outpackServerUrl = "http://127.0.0.1:${toString ports."${name}".outpack}";
-        orderlyRunnerApiUrl = "http://127.0.0.1:${toString ports.orderly-runner-api}";
+        orderlyRunnerApiUrl = "http://127.0.0.1:${toString config.services.orderly-runner.port}";
         authentication = {
           github.redirect_url = "https://${cfg.domain}/${name}/redirect";
           service.audience = lib.mkIf (builtins.length config.authentication.service.policies > 0) "https://${cfg.domain}/${name}";
@@ -94,13 +94,6 @@ in
         ] ++ lib.optionals (config.authentication.method == "github") [
           cfg.githubOAuthSecret
         ];
-        properties."java.io.tmpdir" = "/var/tmp";
-
-        # force disable if repositoryUrl not provided otherwise default to
-        # orderly runner enable value
-        runner.enable = if (!(config.runner ? repositoryUrl))
-          then lib.mkForce false
-          else lib.mkDefault orderlyRunnerCfg.enable;
       });
     });
 

--- a/modules/orderly-runner.nix
+++ b/modules/orderly-runner.nix
@@ -2,7 +2,22 @@
 let
   inherit (lib) types;
   imageJson = lib.importJSON ../packages/orderly-runner/image.json;
-  arrayFrom = n: if n == 1 then [ 1 ] else [ n ] ++ arrayFrom (n - 1);
+
+  getOrderlyRunnerContainer = { name, cmdFlags, entrypoint }: {
+    "${name}" = {
+      imageFile = pkgs.dockerTools.pullImage imageJson;
+      image = "${imageJson.finalImageName}:${imageJson.finalImageTag}";
+      extraOptions = [ "--network=host" "--pull=never" ];
+      environment = {
+        REDIS_URL = "redis://localhost";
+        ORDERLY_RUNNER_QUEUE_ID = "orderly.runner.queue";
+      };
+      entrypoint = entrypoint;
+      cmd = [ "/data" ] ++ cmdFlags;
+      serviceName = name;
+      volumes = [ "logs-volume:/logs" ];
+    };
+  };
 in
 {
   options.services.orderly-runner = {
@@ -17,40 +32,23 @@ in
     };
   };
 
-  config.services.redis.servers.orderly-runner = {
-    enable = true;
-    port = 6379;
-  };
-
-  config.virtualisation.oci-containers.containers = {
-    orderly-runner-api = rec {
-      imageFile = pkgs.dockerTools.pullImage imageJson;
-      image = "${imageJson.finalImageName}:${imageFile.imageTag}";
-      extraOptions = [ "--network=host" "--pull=never" ];
-      environment = {
-        REDIS_URL = "redis://localhost";
-        ORDERLY_RUNNER_QUEUE_ID = "orderly.runner.queue";
-      };
-      entrypoint = "/usr/local/bin/orderly.runner.server";
-      cmd = [ "/data" "--port=${builtins.toString config.services.orderly-runner.port}" ];
-      serviceName = "orderly-runner-api";
-      volumes = [ "logs-volume:/logs" ];
+  config = lib.mkIf config.services.orderly-runner.enable {
+    services.redis.servers.orderly-runner = {
+      enable = true;
+      port = 6379;
     };
-  } // lib.mergeAttrsList (map (num:
-    let name = "orderly-runner-worker-${builtins.toString num}";
-    in {
-      "${name}" = rec {
-        imageFile = pkgs.dockerTools.pullImage imageJson;
-        image = "${imageJson.finalImageName}:${imageFile.imageTag}";
-        extraOptions = [ "--network=host" "--pull=never" ];
-        environment = {
-          REDIS_URL = "redis://localhost";
-          ORDERLY_RUNNER_QUEUE_ID = "orderly.runner.queue";
-        };
-        entrypoint = "/usr/local/bin/orderly.runner.worker";
-        cmd = [ "/data" ];
-        serviceName = name;
-        volumes = [ "logs-volume:/logs" ];
-      };
-    }) (arrayFrom config.services.orderly-runner.workers));
+
+    virtualisation.oci-containers.containers =
+      getOrderlyRunnerContainer {
+        name = "orderly-runner-api";
+        cmdFlags = [ "--port=${builtins.toString config.services.orderly-runner.port}" ];
+        entrypoint = "/usr/local/bin/orderly.runner.server";
+      } // lib.mergeAttrsList (lib.genList (num:
+        getOrderlyRunnerContainer {
+          name = "orderly-runner-worker-${builtins.toString num}";
+          cmdFlags = [];
+          entrypoint = "/usr/local/bin/orderly.runner.worker";
+        }
+      ) config.services.orderly-runner.workers);
+  };
 }

--- a/modules/orderly-runner.nix
+++ b/modules/orderly-runner.nix
@@ -1,0 +1,56 @@
+{ self, pkgs, config, lib, ... }:
+let
+  inherit (lib) types;
+  imageJson = lib.importJSON ../packages/orderly-runner/image.json;
+  arrayFrom = n: if n == 1 then [ 1 ] else [ n ] ++ arrayFrom (n - 1);
+in
+{
+  options.services.orderly-runner = {
+    enable = lib.mkEnableOption "Orderly runner API";
+    workers = lib.mkOption {
+      description = "Number of workers to spin up";
+      type = types.int;
+    };
+    port = lib.mkOption {
+      type = types.port;
+      default = 8240;
+    };
+  };
+
+  config.services.redis.servers.orderly-runner = {
+    enable = true;
+    port = 6379;
+  };
+
+  config.virtualisation.oci-containers.containers = {
+    orderly-runner-api = rec {
+      imageFile = pkgs.dockerTools.pullImage imageJson;
+      image = "${imageJson.finalImageName}:${imageFile.imageTag}";
+      extraOptions = [ "--network=host" "--pull=never" ];
+      environment = {
+        REDIS_URL = "redis://localhost";
+        ORDERLY_RUNNER_QUEUE_ID = "orderly.runner.queue";
+      };
+      entrypoint = "/usr/local/bin/orderly.runner.server";
+      cmd = [ "/data" "--port=${builtins.toString config.services.orderly-runner.port}" ];
+      serviceName = "orderly-runner-api";
+      volumes = [ "logs-volume:/logs" ];
+    };
+  } // lib.mergeAttrsList (map (num:
+    let name = "orderly-runner-worker-${builtins.toString num}";
+    in {
+      "${name}" = rec {
+        imageFile = pkgs.dockerTools.pullImage imageJson;
+        image = "${imageJson.finalImageName}:${imageFile.imageTag}";
+        extraOptions = [ "--network=host" "--pull=never" ];
+        environment = {
+          REDIS_URL = "redis://localhost";
+          ORDERLY_RUNNER_QUEUE_ID = "orderly.runner.queue";
+        };
+        entrypoint = "/usr/local/bin/orderly.runner.worker";
+        cmd = [ "/data" ];
+        serviceName = name;
+        volumes = [ "logs-volume:/logs" ];
+      };
+    }) (arrayFrom config.services.orderly-runner.workers));
+}

--- a/modules/packit-api.nix
+++ b/modules/packit-api.nix
@@ -122,7 +122,6 @@ let
         repositoryUrl = lib.mkOption {
           description = "URL of an orderly repository";
           type = types.str;
-          default = "";
         };
       };
 
@@ -214,7 +213,7 @@ in
         PACKIT_AUTH_REDIRECT_URL = instanceCfg.authentication.github.redirect_url;
         PACKIT_AUTH_GITHUB_ORG = instanceCfg.authentication.github.org;
         PACKIT_AUTH_GITHUB_TEAM = instanceCfg.authentication.github.team;
-      }) // (lib.optionalAttrs (instanceCfg.runner.enable) {
+      }) // (lib.optionalAttrs instanceCfg.runner.enable {
         PACKIT_ORDERLY_RUNNER_URL = instanceCfg.orderlyRunnerApiUrl;
         PACKIT_ORDERLY_RUNNER_REPOSITORY_URL = instanceCfg.runner.repositoryUrl;
         PACKIT_ORDERLY_RUNNER_LOCATION_URL = instanceCfg.outpackServerUrl;

--- a/modules/packit-api.nix
+++ b/modules/packit-api.nix
@@ -44,6 +44,8 @@ let
     };
   };
 
+  orderlyRunnerEnableDefault = config.services.orderly-runner.enable;
+
   instanceModule = { name, config, ... }: {
     options = {
       enable = lib.mkEnableOption "the Packit API server";
@@ -60,6 +62,10 @@ let
       };
       outpackServerUrl = lib.mkOption {
         default = "http://127.0.0.1:8000";
+        type = types.str;
+      };
+      orderlyRunnerApiUrl = lib.mkOption {
+        default = "http://127.0.0.1:8001";
         type = types.str;
       };
 
@@ -106,6 +112,19 @@ let
             type = types.listOf (lib.types.submodule policyModule);
             default = [ ];
           };
+        };
+      };
+
+      runner = rec {
+        enable = lib.mkOption {
+          description = "Enable instance to use orderly runners";
+          type = types.bool;
+          default = orderlyRunnerEnableDefault;
+        };
+        repositoryUrl = lib.mkOption {
+          description = "URL of an orderly repository";
+          type = types.str;
+          default = "";
         };
       };
 
@@ -192,10 +211,15 @@ in
         PACKIT_DEFAULT_ROLES = lib.concatStringsSep "," instanceCfg.defaultRoles;
         PACKIT_CORS_ALLOWED_ORIGINS = lib.concatStringsSep "," instanceCfg.corsAllowedOrigins;
         PACKIT_AUTH_METHOD = instanceCfg.authentication.method;
+        PACKIT_ORDERLY_RUNNER_ENABLED = if (instanceCfg.runner.enable && instanceCfg.runner.repositoryUrl != "") then "true" else "false";
       } // (lib.optionalAttrs (instanceCfg.authentication.method == "github") {
         PACKIT_AUTH_REDIRECT_URL = instanceCfg.authentication.github.redirect_url;
         PACKIT_AUTH_GITHUB_ORG = instanceCfg.authentication.github.org;
         PACKIT_AUTH_GITHUB_TEAM = instanceCfg.authentication.github.team;
+      }) // (lib.optionalAttrs (instanceCfg.runner.enable && instanceCfg.runner.repositoryUrl != "") {
+        PACKIT_ORDERLY_RUNNER_URL = instanceCfg.orderlyRunnerApiUrl;
+        PACKIT_ORDERLY_RUNNER_REPOSITORY_URL = instanceCfg.runner.repositoryUrl;
+        PACKIT_ORDERLY_RUNNER_LOCATION_URL = instanceCfg.outpackServerUrl;
       });
     };
   });

--- a/modules/packit-api.nix
+++ b/modules/packit-api.nix
@@ -44,8 +44,6 @@ let
     };
   };
 
-  orderlyRunnerEnableDefault = config.services.orderly-runner.enable;
-
   instanceModule = { name, config, ... }: {
     options = {
       enable = lib.mkEnableOption "the Packit API server";
@@ -115,11 +113,11 @@ let
         };
       };
 
-      runner = rec {
+      runner = {
         enable = lib.mkOption {
           description = "Enable instance to use orderly runners";
           type = types.bool;
-          default = orderlyRunnerEnableDefault;
+          default = false;
         };
         repositoryUrl = lib.mkOption {
           description = "URL of an orderly repository";
@@ -211,12 +209,12 @@ in
         PACKIT_DEFAULT_ROLES = lib.concatStringsSep "," instanceCfg.defaultRoles;
         PACKIT_CORS_ALLOWED_ORIGINS = lib.concatStringsSep "," instanceCfg.corsAllowedOrigins;
         PACKIT_AUTH_METHOD = instanceCfg.authentication.method;
-        PACKIT_ORDERLY_RUNNER_ENABLED = if (instanceCfg.runner.enable && instanceCfg.runner.repositoryUrl != "") then "true" else "false";
+        PACKIT_ORDERLY_RUNNER_ENABLED = if (instanceCfg.runner.enable) then "true" else "false";
       } // (lib.optionalAttrs (instanceCfg.authentication.method == "github") {
         PACKIT_AUTH_REDIRECT_URL = instanceCfg.authentication.github.redirect_url;
         PACKIT_AUTH_GITHUB_ORG = instanceCfg.authentication.github.org;
         PACKIT_AUTH_GITHUB_TEAM = instanceCfg.authentication.github.team;
-      }) // (lib.optionalAttrs (instanceCfg.runner.enable && instanceCfg.runner.repositoryUrl != "") {
+      }) // (lib.optionalAttrs (instanceCfg.runner.enable) {
         PACKIT_ORDERLY_RUNNER_URL = instanceCfg.orderlyRunnerApiUrl;
         PACKIT_ORDERLY_RUNNER_REPOSITORY_URL = instanceCfg.runner.repositoryUrl;
         PACKIT_ORDERLY_RUNNER_LOCATION_URL = instanceCfg.outpackServerUrl;

--- a/packages/orderly-runner/image.json
+++ b/packages/orderly-runner/image.json
@@ -1,0 +1,7 @@
+{
+  "imageName": "mrcide/orderly.runner",
+  "imageDigest": "sha256:0b89666b4b000fedd033baea7eceedff771a841ef7dd809a788a76f3d3e8d11d",
+  "sha256": "sha256-9WduEJ8QnxWQDlKJInUTj6TP+JcYMvsX4A7jur9FRSw=",
+  "finalImageName": "mrcide/orderly.runner",
+  "finalImageTag": "main-0b89666b4b000fedd033baea7eceedff771a841ef7dd809a788a76f3d3e8d11d"
+}

--- a/packages/packit/sources.json
+++ b/packages/packit/sources.json
@@ -2,8 +2,8 @@
   "src": {
     "owner": "mrc-ide",
     "repo": "packit",
-    "rev": "b3d2baca0b31a4b74916d9b900f606bf99b3074d",
-    "hash": "sha256-5J6aejCkmj/BUra4hRU3Gpr4mdq07tSsk/AV0dWxuDo="
+    "rev": "d602302f6febb1dcc43cc97b822771a5b95b4b43",
+    "hash": "sha256-gAdFiTErzkInAsLXSN+nhtzgFuuSRjF6Qv+BVhMuWiM="
   },
   "gradleDepsHash": "sha256-c20j36U70SH4g06DiuH7+QPMa3DJLW+a1v9iOFNMSiU=",
   "npmDepsHash": "sha256-tBrad+ebOET9/Xqn1qKUavC8+h2gLupi9XkXI4oAu3Y="

--- a/packages/packit/sources.json
+++ b/packages/packit/sources.json
@@ -2,7 +2,7 @@
   "src": {
     "owner": "mrc-ide",
     "repo": "packit",
-    "rev": "d602302f6febb1dcc43cc97b822771a5b95b4b43",
+    "rev": "607b76594f332a2eece947b27a6e2b8d29bc9c21",
     "hash": "sha256-gAdFiTErzkInAsLXSN+nhtzgFuuSRjF6Qv+BVhMuWiM="
   },
   "gradleDepsHash": "sha256-c20j36U70SH4g06DiuH7+QPMa3DJLW+a1v9iOFNMSiU=",

--- a/vm.nix
+++ b/vm.nix
@@ -1,6 +1,7 @@
 { pkgs, lib, config, ... }:
 {
   virtualisation.memorySize = 2048;
+  virtualisation.diskSize = 16384;
   virtualisation.forwardPorts = [{
     from = "host";
     host.port = 8443;


### PR DESCRIPTION
General strategy right now is to pull docker images for orderly.runner and run them.

Let me know what you think of the ergonomics of this, e.g. I have chosen to default whether runner is available per instance based on whether orderly-runner is enabled.