### PR TITLE
use cargo lock instead of cargodeps hash

### DIFF
--- a/packages/outpack_server/default.nix
+++ b/packages/outpack_server/default.nix
@@ -5,7 +5,7 @@ in
 rustPlatform.buildRustPackage rec {
   name = "outpack_server";
   src = fetchFromGitHub sources.src;
-  cargoHash = sources.cargoDepsHash;
+  cargoLock.lockFile = "${src}/Cargo.lock";
 
   buildInputs = [ openssl ];
   nativeBuildInputs = [ pkg-config ];

--- a/packages/outpack_server/sources.json
+++ b/packages/outpack_server/sources.json
@@ -4,6 +4,5 @@
     "repo": "outpack_server",
     "rev": "d3d2fbd6c549698e7d2a28424d5132144557f159",
     "hash": "sha256-SBe+uivutwzLENGJkkbSHHVrHzrCPGrnGXGz8Vv05sw="
-  },
-  "cargoDepsHash": "sha256-9Ab7sYG/0C9x7+9ZPOhtrebVzHYxWeE3KLyeF4HHye0="
+  }
 }

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -35,7 +35,7 @@ let
 in
 """
 
-SUPPORTED_DEPS = {"gradle", "cargo", "npm"}
+SUPPORTED_DEPS = {"gradle", "npm"}
 
 
 def github_api(path):


### PR DESCRIPTION
My research into those hashes and trying to make that update script better did lead me to the fact that you can give `rustPlatform.buildRustPackage` a cargo lock file and not include the hash!

see https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#importing-a-cargolock-file-importing-a-cargolock-file

I will eventually make it better!