### PR TITLE
Allow running reports from GitHub actions on packit/reside.

### DIFF
--- a/machines/wpia-packit.nix
+++ b/machines/wpia-packit.nix
@@ -45,12 +45,20 @@
         method = "github";
         github.org = "reside-ic";
 
-        service.policies = [{
-          issuer = "https://token.actions.githubusercontent.com";
-          jwkSetUri = "https://token.actions.githubusercontent.com/.well-known/jwks";
-          requiredClaims.repository = "mrc-ide/orderly-action";
-          grantedPermissions = [ "outpack.read" "outpack.write" ];
-        }];
+        service.policies = [
+          {
+            issuer = "https://token.actions.githubusercontent.com";
+            jwkSetUri = "https://token.actions.githubusercontent.com/.well-known/jwks";
+            requiredClaims.repository = "mrc-ide/orderly-action";
+            grantedPermissions = [ "outpack.read" "outpack.write" ];
+          }
+          {
+            issuer = "https://token.actions.githubusercontent.com";
+            jwkSetUri = "https://token.actions.githubusercontent.com/.well-known/jwks";
+            requiredClaims.repository = "reside-ic/packit-infra-test-repo";
+            grantedPermissions = [ "outpack.read" "outpack.write" "packet.run" ];
+          }
+        ];
       };
 
       runner = {


### PR DESCRIPTION
This adds a new policy for OIDC authentication, allowing GitHub actions on the `reside-ic/packit-infra-test-repo` repository to login to the `packit/reside` instance and read/write from outpack, as well as invoke the runner.

This has to be done on `wpia-packit` and not `wpia-packit-dev` as the latter isn't exposed publicly.