### PR TITLE
Fix the enumeration of hostnames.

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -91,11 +91,11 @@ jobs:
             You can deploy this pull request by running the following command:
 
             ```sh
-            nix run "github:${{ github.repository }}?ref=refs/pull/${{ steps.create-pr.outputs.pull-request-number }}/merge#deploy" <hostname>
+            nix run --refresh "github:${{ github.repository }}?ref=refs/pull/${{ steps.create-pr.outputs.pull-request-number }}/merge#deploy" <hostname>
             ```
 
             After merging this pull request, you must deploy the ${{ github.event.repository.default_branch }} branch to each host by running the following command:
 
             ```sh
-            nix run "github:${{ github.repository }}#deploy" <hostname>
+            nix run --refresh "github:${{ github.repository }}#deploy" <hostname>
             ```

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,7 +11,7 @@
 set -eu
 
 if [[ $# != 1 && $# != 2 ]]; then
-  hostnames=$(jq -r 'keys.[] | join(",")' $NIXOS_CONFIGURATIONS)
+  hostnames=$(jq -r 'keys | join(", ")' $NIXOS_CONFIGURATIONS)
   cat >&2 <<EOF
 Usage: $0 hostname [switch|boot|test|dry-activate]
 Valid hostnames: $hostnames

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -11,7 +11,7 @@
 set -eu
 
 if [[ $# -lt 1 ]]; then
-  hostnames=$(jq -r 'keys.[] | join(",")' $NIXOS_CONFIGURATIONS)
+  hostnames=$(jq -r 'keys | join(", ")' $NIXOS_CONFIGURATIONS)
   cat >&2 <<EOF
 Usage: $0 hostname
 Valid hostnames: $hostnames

--- a/scripts/start-vm.sh
+++ b/scripts/start-vm.sh
@@ -1,7 +1,7 @@
 set -eu
 
 if [[ $# -lt 1 ]]; then
-  hostnames=$(jq -r 'keys.[] | join(",")' $VM_CONFIGURATIONS)
+  hostnames=$(jq -r 'keys | join(", ")' $VM_CONFIGURATIONS)
   cat >&2 <<EOF
 Usage: $0 hostname ...
 Valid hostnames: $hostnames


### PR DESCRIPTION
The last change to the deploy scripts broke the enumeration of available hostnames, which gets printed when someone runs `nix run .#deploy` without arguments.

I've also updated the command that gets commented on automatic update pull requests to include the `--refresh` argument. Without it, Nix tends to cache the repository contents, and might not end up deploying the lastest version of it.