### PR TITLE
Use cache-nix-action in the test workflow

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: nixbuild/nix-quick-install-action@v27
       - name: Run nix-diff
         run: |
           hostnames=$(nix eval --raw ".#nixosConfigurations" --apply 'x: builtins.concatStringsSep " " (builtins.attrNames x)')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,20 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
+
+      # We need this to be able to run VM-based tests
+      # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: nixbuild/nix-quick-install-action@v27
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}
+
       - run: |
           hostnames=$(nix eval --raw ".#nixosConfigurations" --apply 'x: builtins.concatStringsSep " " (builtins.attrNames x)')
           for h in $hostnames; do

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: nixbuild/nix-quick-install-action@v27
 
       - name: Update outpack_server
         run: nix run .#update outpack_server -- --ref ${{ inputs.outpack_server || 'HEAD' }} --write-commit-log ${{ runner.temp }}/outpack_server.md


### PR DESCRIPTION
The test workflow takes a significant amount of time to run (about 15 minutes) as it needs to rebuild outpack_server and Packit each time.

In theory Nix should be great as caching those built artefacts while precisely be able to determine when they need rebuilding. This is more or less what we had in place when we used the magic-nix-cache action.

Unfortunately that action was using an undocumented GitHub API, which has now been sunset without a supported replacement.

The cache-nix-action action can be used instead, as it only uses the documented GitHub APIs for this. However it works in a different way, as it saves and restores the entire `/nix` store, whereas the magic-nix-cache action would save and restore each built derivation as a separate artefact.

Saving the whole store is not as powerful, and in particular there's a risk of the store growing everytime we need to build a new versions of the packages, until we hit GitHub's storage limit. Because the whole store is a single artefact, GitHub's cache cannot evict the individual packages we have not used in a long time. If and when this becomes an issue we'll need to look into adding own our garbage collection stage at the end of the workflow, where we only keep the derivations that we've accessed.