### PR TITLE
Make packit-api a `notify` service.

### DIFF
--- a/modules/packit-api.nix
+++ b/modules/packit-api.nix
@@ -183,7 +183,7 @@ in
       after = [ "postgresql.service" ];
 
       serviceConfig = {
-        Type = "simple";
+        Type = "notify";
         DynamicUser = true;
         ProtectSystem = true;
 

--- a/tests/integration/script.py
+++ b/tests/integration/script.py
@@ -7,7 +7,7 @@ machine.wait_for_unit("multi-user.target")
 
 api_url = "https://localhost/reside/packit/api"
 
-response = machine.wait_until_succeeds(f"curl -sSfk {api_url}/auth/config")
+response = machine.succeed(f"curl -sSfk {api_url}/auth/config")
 data = json.loads(response)
 assert data == {
   "enableAuth": True,


### PR DESCRIPTION
Packit is pretty slow to start. Using `notify` as the service type allows us to track within systemd whether it is still starting or if it is started and accepting connections.

In the future this may even allow us to run some provisioning steps (eg. creating basic users, creating roles, seeding the `reside-dev` instance with test data, ...) that express a dependency on Packit being up and running.