### PR TITLE
Fix usage of Nix cache in GitHub actions.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,8 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v27
       - uses: nix-community/cache-nix-action@v6
         with:
-          primary-key: nix-${{ runner.os }}
+          primary-key: nix-${{ runner.os }}-${{ github.sha }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - run: |
           hostnames=$(nix eval --raw ".#nixosConfigurations" --apply 'x: builtins.concatStringsSep " " (builtins.attrNames x)')


### PR DESCRIPTION
Turns out I'd misinterpreted the semantics of the primary key. If we use a static key (as I had), the action will never overwrite an existing cache, meaning we were just using the first cached store that was created.

Instead we should use a cache key that reflects the contents of the repository. If this key does not exist yet, the action will pull any cached store that matches a common prefix.

In a more traditional setting, the cache key might depend on just the contents of one file (say a `package-lock.json` if caching NPM dependencies), but in this context we are interested in caching the entire build so I think it makes sense to use the commit hash as the cache key.