### PR TITLE
Get certificates for packit-dev from Let's Encrypt.

### DIFF
--- a/machines/common/acme.nix
+++ b/machines/common/acme.nix
@@ -1,0 +1,94 @@
+{ self', lib, pkgs, config, ... }:
+let
+  # We use Let's Encrypt to provision automatically certificates for nginx.
+  #
+  # To get the certificates we need to prove ownership of the domains in an
+  # automated fashion. The easiest way to do this is by hosting a challenge
+  # on an http server and have Let's Encrypt fetch that challenge and check its
+  # contents.
+  #
+  # Unfortunately some of our machines are behind a firewall and are only
+  # accessible from within the DIDE network. To prove ownership of these
+  # domains, we have to use a DNS challenge instead. This requires us to
+  # be able to programatically configure a TXT DNS record on
+  # `_acme-challenge.<hostname>.dide.ic.ac.uk`. Our DNS entries are managed by
+  # ICT, using "HDB" as their source of truth. ICT provides an API to add
+  # entries for this exact purpose.
+  #
+  # To make things simpler, we use DNS challenges across the board, even on
+  # machines that are exposed publicly.
+  #
+  # The bash script below is used to interact with the HDB API. The script is
+  # called by Lego, the ACME client used by NixOS, when we need to publish the
+  # TXT DNS record.
+  #
+  # See https://go-acme.github.io/lego/dns/exec/ for the input specification.
+  #
+  # ICT did provide us with a certbot plugin, but integrating certbot into NixOS
+  # would have been more work than integrating the HDB API into Lego.
+  hdb-acme = pkgs.writeShellApplication {
+    name = "hdb-acme";
+    text = ''
+      # shellcheck source=/dev/null
+      source "$HDB_ACME_CREDENTIALS_FILE"
+      action="$1"
+
+      # Lego passes a trailing dot in the FQDN, which the HDB API refuses to
+      # accept. This line below is removes it, if present.
+      fqdn="''${2%.}"
+      value="$3"
+
+      case $action in
+        present) method="PUT" ;;
+        cleanup) method="DELETE" ;;
+        *) exit 1 ;;
+      esac
+
+      # For some reason, the HDB API requires the token to be wrapped in an
+      # extra layer of quotes, which is why we have a `tojson` call here.
+      jq --null-input --arg value "$value" '{ token: $value | tojson }' |
+        curl --no-progress-meter --fail --output /dev/null \
+          --request "$method" --json @- \
+          --basic -u "$HDB_ACME_USERNAME:$HDB_ACME_PASSWORD" \
+          "https://hdb.ic.ac.uk/api/acme/v0/$fqdn/auth_token"
+    '';
+    runtimeInputs = [ pkgs.jq pkgs.curl ];
+  };
+
+  usesACME = config.security.acme.certs != { };
+in
+{
+  security.acme = {
+    acceptTerms = true;
+    defaults = {
+      email = "reside@imperial.ac.uk";
+      dnsProvider = "exec";
+      environmentFile = pkgs.writeText "env" ''
+        EXEC_PATH="${lib.getExe hdb-acme}"
+        EXEC_PROPAGATION_TIMEOUT=210
+        # ICT makes the _acme-challenge record a CNAME, and by default Lego
+        # follows that CNAME and tries to update the underlying record. That's
+        # not what we want, so this disables that.
+        LEGO_DISABLE_CNAME_SUPPORT=true
+      '';
+      credentialFiles = {
+        HDB_ACME_CREDENTIALS_FILE = "/var/secrets/hdb-acme/credentials";
+      };
+    };
+  };
+
+  # We only bother fetching the HDB credentials if we have any ACME
+  # certificates.
+  vault.secrets = lib.mkIf usesACME {
+    "hdb-acme-credentials" = {
+      format = "env";
+      path = "/var/secrets/hdb-acme/credentials";
+      key = "certbot-hdb/credentials";
+      fields.HDB_ACME_USERNAME = "username";
+      fields.HDB_ACME_PASSWORD = "password";
+    };
+  };
+
+  # This can be handy for debugging
+  environment.systemPackages = lib.mkIf usesACME [ hdb-acme ];
+}

--- a/machines/common/base.nix
+++ b/machines/common/base.nix
@@ -8,6 +8,7 @@
     ../../modules/packit-api.nix
     ../../modules/orderly-runner.nix
     ../../modules/metrics-proxy.nix
+    ./acme.nix
     ./tools.nix
     inputs.disko.nixosModules.disko
   ];

--- a/machines/common/services.nix
+++ b/machines/common/services.nix
@@ -16,20 +16,14 @@
   };
 
   services.multi-packit = {
-    sslCertificate = "/var/secrets/packit.cert";
-    sslCertificateKey = "/var/secrets/packit.key";
     githubOAuthSecret = "/var/secrets/github-oauth";
   };
 
-  vault.secrets = {
-    ssl-certificate.path = "/var/secrets/packit.cert";
-    ssl-key.path = "/var/secrets/packit.key";
-    github-oauth = {
-      path = "/var/secrets/github-oauth";
-      fields.PACKIT_GITHUB_CLIENT_ID = "clientId";
-      fields.PACKIT_GITHUB_CLIENT_SECRET = "clientSecret";
-      format = "env";
-    };
+  vault.secrets.github-oauth = {
+    path = "/var/secrets/github-oauth";
+    format = "env";
+    fields.PACKIT_GITHUB_CLIENT_ID = "clientId";
+    fields.PACKIT_GITHUB_CLIENT_SECRET = "clientSecret";
   };
 
   services.metrics-proxy = {

--- a/machines/wpia-packit-dev.nix
+++ b/machines/wpia-packit-dev.nix
@@ -8,16 +8,15 @@
 
   networking.hostName = "wpia-packit-dev";
 
-  vault.secrets = {
-    "ssl-certificate".key = "packit/ssl/dev/cert";
-    "ssl-key".key = "packit/ssl/dev/key";
-    "github-oauth".key = "packit/oauth/dev";
-  };
+  vault.secrets."github-oauth".key = "packit/oauth/dev";
+
   services.multi-packit = {
     enable = true;
+    enableACME = true;
     domain = "packit-dev.dide.ic.ac.uk";
     instances = [ "reside-dev" ];
   };
+
   services.packit-api.instances = {
     reside-dev = {
       defaultRoles = [ "ADMIN" ];

--- a/machines/wpia-packit-private.nix
+++ b/machines/wpia-packit-private.nix
@@ -8,16 +8,24 @@
 
   networking.hostName = "wpia-packit-private";
 
+  vault.secrets = {
+    github-oauth.key = "packit/oauth/private";
+    ssl-certificate = {
+      path = "/var/secrets/packit.cert";
+      key = "packit/ssl/private/cert";
+    };
+    ssl-key = {
+      path = "/var/secrets/packit.key";
+      key = "packit/ssl/private/key";
+    };
+  };
+
   services.multi-packit = {
     enable = true;
     domain = "packit-private.dide.ic.ac.uk";
+    sslCertificate = "/var/secrets/packit.cert";
+    sslCertificateKey = "/var/secrets/packit.key";
     instances = [ "kipling" ];
-  };
-
-  vault.secrets = {
-    "ssl-certificate".key = "packit/ssl/private/cert";
-    "ssl-key".key = "packit/ssl/private/key";
-    "github-oauth".key = "packit/oauth/private";
   };
 
   services.packit-api.instances = {

--- a/machines/wpia-packit.nix
+++ b/machines/wpia-packit.nix
@@ -9,14 +9,22 @@
   networking.hostName = "wpia-packit";
 
   vault.secrets = {
-    "ssl-certificate".key = "packit/ssl/production/cert";
-    "ssl-key".key = "packit/ssl/production/key";
-    "github-oauth".key = "packit/oauth/production";
+    github-oauth.key = "packit/oauth/production";
+    ssl-certificate = {
+      path = "/var/secrets/packit.cert";
+      key = "packit/ssl/production/cert";
+    };
+    ssl-key = {
+      path = "/var/secrets/packit.key";
+      key = "packit/ssl/production/key";
+    };
   };
 
   services.multi-packit = {
     enable = true;
     domain = "packit.dide.ic.ac.uk";
+    sslCertificate = "/var/secrets/packit.cert";
+    sslCertificateKey = "/var/secrets/packit.key";
     instances = [
       "priority-pathogens"
       "reside"

--- a/modules/multi-packit.nix
+++ b/modules/multi-packit.nix
@@ -36,6 +36,11 @@ in
       description = "the domain name on which the service is hosted";
       type = types.str;
     };
+    enableACME = lib.mkOption {
+      description = "Obtain certificates from Let's Encrypt";
+      type = types.bool;
+      default = false;
+    };
     sslCertificate = lib.mkOption {
       type = types.path;
     };
@@ -123,7 +128,13 @@ in
         absolute_redirect OFF;
       '';
 
-      inherit (cfg) sslCertificate sslCertificateKey;
+      enableACME = cfg.enableACME;
+      # By default nginx will enable the http challenge and try to host
+      # challenges under `/.well-known`. Set to null to not do that.
+      acmeRoot = null;
+
+      sslCertificate = lib.mkIf (!cfg.enableACME) cfg.sslCertificate;
+      sslCertificateKey = lib.mkIf (!cfg.enableACME) cfg.sslCertificateKey;
 
       root = landingPage;
       locations = foreachInstance (name: {

--- a/tests/integration/default.nix
+++ b/tests/integration/default.nix
@@ -16,9 +16,6 @@ pkgs.testers.runNixOSTest {
 
     services.multi-packit = {
       enable = true;
-      sslCertificate = "/var/secrets/packit.cert";
-      sslCertificateKey = "/var/secrets/packit.key";
-      githubOAuthSecret = "/var/secrets/github-oauth";
       instances = [ "reside" ];
     };
 

--- a/vm.nix
+++ b/vm.nix
@@ -11,6 +11,12 @@
 
   services.multi-packit = {
     domain = lib.mkForce "localhost:8443";
+
+    # Never use ACME on local VMs. We use self-signed certificates instead,
+    # see below for the generation.
+    enableACME = lib.mkForce false;
+    sslCertificate = lib.mkForce "/var/secrets/packit.cert";
+    sslCertificateKey = lib.mkForce "/var/secrets/packit.key";
   };
 
   vault.secrets = lib.mkForce {


### PR DESCRIPTION
To get the certificates we need to prove ownership of the domains in an automated fashion. The easiest way to do this is by hosting a challenge on an http server and have Let's Encrypt fetch that challenge and check its contents.

Unfortunately some of our machines are behind a firewall and are only accessible from within the DIDE network. To prove ownership of these domains, we have to use a DNS challenge instead. This requires us to be able to programatically configure a TXT DNS record on `_acme-challenge.<hostname>.dide.ic.ac.uk`. Our DNS entries are managed by ICT, using "HDB" as their source of truth. ICT provides an API to add entries for this exact purpose.

ICT did give us a certbot plugin to interact with their API, however NixOS already has very good integration with a different ACME client, Lego. Adding a new DNS provider implementation to Lego was quite easy, as we can just get Lego to call out to an external script, and all that script needs to do is make a `PUT` or `DELETE` call to the HDB API.

For now only packit-dev is using Let's Encrypt, although there is nothing preventing us from using it on other hosts - I will probably deploy it to the others very soon.

The local VMs never use Let's Encrypt. They use the same self-signed certificates we were already using before.