### PR TITLE
Make the configuration drift metrics more precise.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,3 +35,29 @@ jobs:
           done
 
       - run: nix flake check -L
+
+      - name: Build repository metrics
+        run: nix build .#repository-metrics --out-link ${{ runner.temp }}/metrics
+      - name: Save repository metrics as an artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ runner.temp }}/metrics
+
+  # We deploy metrics about the build to GitHub pages, so it can be scraped our
+  # Prometheus. The metrics always get built, but we only actually publish them
+  # on main branch builds.
+  deploy-metrics:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,13 @@
           pkgs.nix-diff
         ];
       };
+
+      # This gets published to GitHub pages for Prometheus to scrape.
+      packages.repository-metrics = pkgs.concatTextFile {
+        name = "repository-metrics";
+        files = lib.mapAttrsToList (_: c: c.config.system.build.sourceInfoMetrics or null) self.nixosConfigurations;
+        destination = "/metrics";
+      };
     };
 
     systems = [ "x86_64-linux" ];

--- a/machines/common/base.nix
+++ b/machines/common/base.nix
@@ -10,6 +10,7 @@
     ../../modules/metrics-proxy.nix
     ./acme.nix
     ./tools.nix
+    ./configuration-info.nix
     inputs.disko.nixosModules.disko
   ];
 

--- a/machines/common/configuration-info.nix
+++ b/machines/common/configuration-info.nix
@@ -1,0 +1,89 @@
+# NixOS allows us to configure our machines declaratively and track the
+# configuration in a GitHub repository. In theory, one can have a good
+# understanding of the state of a machine by looking at the configuration files
+# in the source repository.
+#
+# Unfortunately it is easy for a machine to become out of sync with the
+# upstream repository and to "drift" away. There are two main reasons this can
+# happen:
+# - A change is made to the main branch of the repository, but that change
+#   doesn't get deployed to all the machines it affects.
+# - An experimental change is made on a local branch of the repository and is
+#   deployed to one or more machines, but that change is never merged into main
+#   (or it is merged in a different form).
+#
+# Either situation is harmless in the short term, but in the long term it is
+# easy to forget to reconcile the state of the machines with the state of the
+# repository, and find ourselves months later with machines that do not match
+# their declarative configuration.
+#
+# This file attempts to detect and address this issue using Prometheus metrics
+# and alerts. We configure each machine to expose as a metric the hash of its
+# configuration. This metric is periodically scraped by Prometheus and stored
+# in the TSDB. In parallel, we build the latest commit from the main branch on
+# GitHub, compute its hash and store the result on GitHub pages. Prometheus is
+# configured to scrape GitHub pages and scrape those hashes too. If the hash of
+# a configuration deployed to a machine diverges from the hash produced by the
+# upstream build, an alert is fired.
+#
+# There are two caveats to the way we implement this:
+# - The configuration cannot include as one of its inputs the hash of its
+#   output. That would be equivalent to solving the fixpoint of a cryptographic
+#   hash, which is impossible.
+# - We are interested in recording the Git revision that produced a system's
+#   configuration, but at the same time we don't want to have to re-deploy a
+#   machine if the Git revision has changed but the configuration has not (eg.
+#   a documentation change, or a change that only affects a subset of machines).
+#
+# To work around both of the caveats, the system hash we measure is actually of
+# an ever-so-slightly modified configuration, one where the metric for the
+# configuration is not exposed. This hash does not depend on itself, nor does it
+# depend on the exact Git revision of the input.
+
+{ pkgs, inputs, extendModules, config, ... }:
+let
+  # Export the NAR hash of a derivation, writing it to a file.
+  #
+  # By setting `__structuredAttrs`, Nix provide a `NIX_ATTRS_JSON_FILE`
+  # environment variable pointing to a JSON with lots of metadata about the
+  # build context. Using `exportReferencesGraph`, that file includes
+  # information about the given path, including its NAR hash.
+  writeNarHash = p: pkgs.runCommand "${p.name}-narHash"
+    {
+      __structuredAttrs = true;
+      exportReferencesGraph.closure = [ p ];
+      nativeBuildInputs = [ pkgs.jq ];
+    } ''
+    jq -r --arg path "${p}" '.closure[] | select(.path == $path).narHash' < $NIX_ATTRS_JSON_FILE > $out
+  '';
+
+  # This is the modified system configuration whose hash is used. It is
+  # identical to the actual system configuration, but the metric including the
+  # system hash is removed to avoid the cyclic definition.
+  withoutConfigurationInfo = extendModules {
+    modules = [{
+      environment.etc."metrics/configuration-info.prom".enable = false;
+    }];
+  };
+  systemHash = writeNarHash withoutConfigurationInfo.config.system.build.toplevel;
+
+  rev = inputs.self.rev or inputs.self.dirtyRev or "unknown";
+
+  hostname = config.networking.hostName;
+  sourceInfoMetrics = pkgs.runCommand "${hostname}-source-info.prom" { } ''
+    cat >$out <<EOF
+    nixos_source_info{hostname="${hostname}", revision="${rev}", narHash="$(cat ${systemHash})"}
+    EOF
+  '';
+
+  configurationInfoMetrics = pkgs.runCommand "${hostname}-configuration-info.prom" { } ''
+    cat > $out <<EOF
+    nixos_configuration_info{hostname="${hostname}", revision="${rev}", narHash="$(cat ${systemHash})"}
+    EOF
+  '';
+in
+{
+  system.build.withoutConfigurationInfo = withoutConfigurationInfo;
+  system.build.sourceInfoMetrics = sourceInfoMetrics;
+  environment.etc."metrics/configuration-info.prom".source = configurationInfoMetrics;
+}

--- a/machines/common/configuration-info.nix
+++ b/machines/common/configuration-info.nix
@@ -44,7 +44,7 @@
 let
   # Export the NAR hash of a derivation, writing it to a file.
   #
-  # By setting `__structuredAttrs`, Nix provide a `NIX_ATTRS_JSON_FILE`
+  # By setting `__structuredAttrs`, Nix provides a `NIX_ATTRS_JSON_FILE`
   # environment variable pointing to a JSON with lots of metadata about the
   # build context. Using `exportReferencesGraph`, that file includes
   # information about the given path, including its NAR hash.

--- a/machines/common/services.nix
+++ b/machines/common/services.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, inputs, ... }:
+{ config, ... }:
 {
   services.nginx.enable = true;
   services.postgresql = {
@@ -34,15 +34,6 @@
       labels.job = "machine-metrics";
     };
   };
-
-  environment.etc."metrics/static-metrics.prom".text =
-    let
-      inherit (inputs) self;
-      rev = self.rev or self.dirtyRev or "unknown";
-    in
-    ''
-      nixos_configuration_info{revision="${rev}"} 1
-    '';
 
   services.prometheus.exporters = {
     node = {


### PR DESCRIPTION
We have some alerts configured that are used to detect configuration drift between the state of the repository and what is actually deployed on the machines.

Currently the alerts fire if the Git revision between the two differs, which makes the alerts very sensitive. Any change at all requires all machines to be redeployed, even if the change only affects a subset of them (or none, in the case of a documentation-only change for example).

A better way to detect this is to track the hash of the built system instead, which Nix makes very easy to obtain.

In the past we could get Prometheus to scrape the revision of the repository by calling the GitHub API. To get the hash of the built system requires a little more complexity, as we need to actually build the repository. Rather than build repeatedly on every scrape, we can use GitHub actions to produce the metrics and host them onto GitHub pages. We can point Prometheus directly at the right URL and get metrics about the build.

There are a few more caveats to including the system's hash in the output. These are described in detail, along with the workaround used, in `machines/common/configuration-info.nix`.