### PR TITLE
Only save the cache if run on a push to the main branch.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,9 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ github.sha }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
+          # Only save the cache for pushes to main. This avoids blowing up the
+          # cache allowance with PR builds.
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - run: |
           hostnames=$(nix eval --raw ".#nixosConfigurations" --apply 'x: builtins.concatStringsSep " " (builtins.attrNames x)')


### PR DESCRIPTION
GitHub only gives us 10GB of free cached data on GitHub actions, and caching the Nix store already takes up 3GB.

If we save the cache from every run, we quickly end up in a situation where cached stores from the main branch are evicted to make space for the pull request builds.

Because of GitHub's cache access protections, a cache produced by a pull request is never used by the main branch or other pull requests. On the other hand, caches produced by the main branch can be used by any pull request.

We should prioritise giving space to the main branch caches, ensuring all of our builds benefit from the cache.

We could set up a cleverer eviction policy, eg. always keep the most recent main branch cache while also saving caches from branches if there is enough space for it, but this seems pretty overkill.