### PR TITLE
Fix invalid configuration info metric.

### DIFF
--- a/machines/common/configuration-info.nix
+++ b/machines/common/configuration-info.nix
@@ -78,7 +78,7 @@ let
 
   configurationInfoMetrics = pkgs.runCommand "${hostname}-configuration-info.prom" { } ''
     cat > $out <<EOF
-    nixos_configuration_info{hostname="${hostname}", revision="${rev}", narHash="$(cat ${systemHash})"}
+    nixos_configuration_info{hostname="${hostname}", revision="${rev}", narHash="$(cat ${systemHash})"} 1
     EOF
   '';
 in


### PR DESCRIPTION
I'd forgotten the actual metric value. This was causing node exporter to fail to parse the file and not expose any of it.