### PR TITLE
Update all, add script to update orderly.runner.

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,6 +1,6 @@
 # This workflow runs nightly and pulls in new version of packit and
 # outpack_server into this repository, by running the `scripts/update.py`
-# script.
+# script. It also updates orderly.runner using `scripts/update-image.py`.
 #
 # If any updates are found, a pull request is created with the changes. If an
 # open pull request already exists, it is updated instead.
@@ -31,6 +31,10 @@ on:
         description: 'Git ref from which to update packit'
         type: string
 
+      orderly-runner:
+        description: 'Tag of the orderly.runner image'
+        type: string
+
 jobs:
   update:
     runs-on: ubuntu-22.04
@@ -46,6 +50,8 @@ jobs:
         run: nix run .#update outpack_server -- --ref ${{ inputs.outpack_server || 'HEAD' }} --write-commit-log ${{ runner.temp }}/outpack_server.md
       - name: Update packit
         run: nix run .#update packit -- --ref ${{ inputs.packit || 'HEAD' }} --write-commit-log ${{ runner.temp }}/packit.md
+      - name: Update orderly.runner
+        run: nix run .#update-image orderly-runner -- --tag ${{ inputs.orderly-runner || 'main' }}
 
       - name: Prepare PR message
         uses: actions/github-script@v7

--- a/packages/orderly-runner/image.json
+++ b/packages/orderly-runner/image.json
@@ -1,7 +1,7 @@
 {
-  "imageName": "mrcide/orderly.runner",
-  "imageDigest": "sha256:0b89666b4b000fedd033baea7eceedff771a841ef7dd809a788a76f3d3e8d11d",
-  "sha256": "sha256-9WduEJ8QnxWQDlKJInUTj6TP+JcYMvsX4A7jur9FRSw=",
-  "finalImageName": "mrcide/orderly.runner",
-  "finalImageTag": "main-0b89666b4b000fedd033baea7eceedff771a841ef7dd809a788a76f3d3e8d11d"
+  "imageName": "ghcr.io/mrc-ide/orderly.runner",
+  "imageDigest": "sha256:ffbb0116b5ce5dddd78bc0e0aa3dae141c13a944ad1a8cc7cbed8ae632d28e60",
+  "sha256": "0k2myx65x1xm0rqvjzdz6q5x8kvfyysbp9zw2yrsna10j01vy4av",
+  "finalImageName": "ghcr.io/mrc-ide/orderly.runner",
+  "finalImageTag": "main"
 }

--- a/packages/outpack_server/sources.json
+++ b/packages/outpack_server/sources.json
@@ -2,8 +2,8 @@
   "src": {
     "owner": "mrc-ide",
     "repo": "outpack_server",
-    "rev": "1bf5911e3054fbbddd54e67a261f92256d69b8fa",
-    "hash": "sha256-CYzH7uvag1IHdg4FIHmwBSoCflEDN+l3KbPi1fLSWr0="
+    "rev": "e435accf82ff2054f999dbf3bd1d3489319c83c6",
+    "hash": "sha256-z2uXIe98ijlVkSU97bUwV/jSOWWhehcSZIIf/4eVgwA="
   },
   "cargoDepsHash": "sha256-JQBbNazWnOx0t80x5bAb6uXjDLdBdYSjXeuf/JnnlzA="
 }

--- a/packages/packit/sources.json
+++ b/packages/packit/sources.json
@@ -2,9 +2,9 @@
   "src": {
     "owner": "mrc-ide",
     "repo": "packit",
-    "rev": "68e703fc9072edf387b1915f559efe8ba949feb7",
-    "hash": "sha256-5U913hDvg0xnm34fVLYt208gd/xV4W5Em8On1hqb8G8="
+    "rev": "b815b6d32d6b175a063b67d30fe6ef1774467b63",
+    "hash": "sha256-36xVF8sQ/SnO0yG5lEpLuQ4wjlSjDnXwYi4Px004mI0="
   },
   "gradleDepsHash": "sha256-0IhSQavqZhUvZxozlzo0wsySrfYUDkB0qtVQjb2fc3k=",
-  "npmDepsHash": "sha256-/W4NlFDd339cafWSPJohpf1zVeeC//6Dck8sISdf7uI="
+  "npmDepsHash": "sha256-4p2tgvfZqHVCDeBj50CB6H4JgBgpRin5zcetEGlkFWA="
 }

--- a/playbooks/updating-packit.md
+++ b/playbooks/updating-packit.md
@@ -30,10 +30,6 @@ The automatic's pull request description includes the list of commits that were
 added compared to the `main` branch of `packit-infra`. The list of commits
 should help you identify whether the update is particularly risky.
 
-> [!IMPORTANT]
-> Updating orderly.runner is currently a manual process. This will be automated
-> as well soon.
-
 ## 2. Run VM integration tests
 
 This repository contains an integration test that largely mimicks the staging

--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -40,6 +40,10 @@
 
       apps = {
         update.program = pkgs.writers.writePython3Bin "update" { } ./update.py;
+        update-image.program = pkgs.writers.writePython3Bin "update-image"
+          {
+            makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ pkgs.nix-prefetch-docker ]}" ];
+          } ./update-image.py;
 
         update-ssh-keys.program = pkgs.writeShellApplication {
           name = "update-ssh-keys";

--- a/scripts/start-vm.sh
+++ b/scripts/start-vm.sh
@@ -22,5 +22,6 @@ fi
 drvPath=$(jq --arg host "$host" -r '.[$host].drvPath' $VM_CONFIGURATIONS)
 mainProgram=$(jq --arg host "$host" -r '.[$host].mainProgram' $VM_CONFIGURATIONS)
 
-exec "$(nix-store --realise "$drvPath")/bin/$mainProgram" \
+storePath=$(nix-store --realise "$drvPath")
+exec "$storePath/bin/$mainProgram" \
    -fw_cfg name=opt/vault-token,string="$token" "${@:2}"

--- a/scripts/update-image.py
+++ b/scripts/update-image.py
@@ -1,0 +1,36 @@
+import os
+import json
+import subprocess
+import argparse
+
+
+def prefetch_docker(image, tag):
+    cmd = [
+        "nix-prefetch-docker",
+        "--json",
+        "--image-name", image,
+        "--image-tag", tag
+    ]
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
+    return json.loads(p.stdout)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("name")
+parser.add_argument("--image")
+parser.add_argument("--tag", default="main")
+
+args = parser.parse_args()
+path = os.path.join("packages", args.name, "image.json")
+
+if args.image is not None:
+    image = args.image
+else:
+    with open(path) as f:
+        metadata = json.load(f)
+    image = metadata["imageName"]
+
+result = prefetch_docker(image, args.tag)
+
+with open(path, "w") as f:
+    json.dump(result, f, indent=2)

--- a/tests/integration/default.nix
+++ b/tests/integration/default.nix
@@ -29,6 +29,11 @@ pkgs.testers.runNixOSTest {
       };
     };
 
+    services.orderly-runner = {
+      enable = true;
+      workers = 1;
+    };
+
     # This sets up an additional HTTP service on port 81 to serve JWK keys.
     # The server supports GET and PUT, allowing the test script to upload its own keys
     systemd.tmpfiles.rules = [ "d /var/www 755 nginx nginx" ];

--- a/tests/integration/script.py
+++ b/tests/integration/script.py
@@ -50,3 +50,10 @@ with subtest("Can login with service token"):
     data = json.loads(response)
     assert data["status"] == "success"
 
+# This is a very minimal test, just making sure the orderly.runner API can start.
+with subtest("orderly.runner"):
+    response = machine.wait_until_succeeds("curl -sSfk http://localhost:8240")
+    data = json.loads(response)
+    assert data["status"] == "success"
+    assert "orderly2" in data["data"]
+    assert "orderly.runner" in data["data"]


### PR DESCRIPTION
The script is a basic wrapper around nix-prefetch-docker.

The way images are referenced is simplified. We used to have a two step process to start images, first loading the image tarball into podman and then starting the container. It turns out we can just use `docker-archive:/path/to/image.tar` instead. Podman will take care of importing the image as needed. This removes the oddity surrounding the `finalImageTag` that the previous version had.