### PR TITLE
Fix device flow configuration

### DIFF
--- a/modules/packit-api.nix
+++ b/modules/packit-api.nix
@@ -87,7 +87,7 @@ let
           type = types.enum [ "basic" "github" ];
         };
         github = {
-          redirect_url = lib.mkOption {
+          redirectUrl = lib.mkOption {
             description = "URL to which to redirect following an authentication attempt";
             type = types.str;
           };
@@ -109,6 +109,11 @@ let
           policies = lib.mkOption {
             type = types.listOf (lib.types.submodule policyModule);
             default = [ ];
+          };
+        };
+        device = {
+          verificationUri = lib.mkOption {
+            type = types.str;
           };
         };
       };
@@ -135,6 +140,7 @@ let
         type = types.listOf types.str;
         default = [ ];
       };
+
       environmentFiles = lib.mkOption {
         type = types.listOf types.path;
         default = [ ];
@@ -209,8 +215,9 @@ in
         PACKIT_CORS_ALLOWED_ORIGINS = lib.concatStringsSep "," instanceCfg.corsAllowedOrigins;
         PACKIT_AUTH_METHOD = instanceCfg.authentication.method;
         PACKIT_ORDERLY_RUNNER_ENABLED = if (instanceCfg.runner.enable) then "true" else "false";
+        PACKIT_DEVICE_AUTH_URL = instanceCfg.authentication.device.verificationUri;
       } // (lib.optionalAttrs (instanceCfg.authentication.method == "github") {
-        PACKIT_AUTH_REDIRECT_URL = instanceCfg.authentication.github.redirect_url;
+        PACKIT_AUTH_REDIRECT_URL = instanceCfg.authentication.github.redirectUrl;
         PACKIT_AUTH_GITHUB_ORG = instanceCfg.authentication.github.org;
         PACKIT_AUTH_GITHUB_TEAM = instanceCfg.authentication.github.team;
       }) // (lib.optionalAttrs instanceCfg.runner.enable {

--- a/modules/packit.nix
+++ b/modules/packit.nix
@@ -82,8 +82,9 @@ let
       outpackServerUrl = "http://127.0.0.1:${toString ports."${name}".outpack}";
       orderlyRunnerApiUrl = "http://127.0.0.1:${toString orderlyRunnerCfg.port}";
       authentication = {
-        github.redirect_url = "https://${name}.${cfg.domain}/redirect";
+        github.redirectUrl = "https://${name}.${cfg.domain}/redirect";
         service.audience = lib.mkIf (lib.length config.authentication.service.policies > 0) "https://${name}.${cfg.domain}";
+        device.verificationUri = "https://${name}.${cfg.domain}/device";
       };
       corsAllowedOrigins = [ "https://${name}.${cfg.domain}" ];
 

--- a/tests/integration/script.py
+++ b/tests/integration/script.py
@@ -1,59 +1,116 @@
-import json
-from jwcrypto.jwk import JWK, JWKSet # type: ignore
-from jwcrypto.jwt import JWT # type: ignore
-from shlex import quote
+import json as jsonpkg
+import shlex
+from urllib.parse import urlencode
+
+from jwcrypto.jwk import JWK, JWKSet  # type: ignore
+from jwcrypto.jwt import JWT  # type: ignore
+
+
+def curl(machine, url, json=None, token=None, method=None, data=None, expect_json=True, wait=False):
+    args = ["curl", "-sSfk"]
+    if method is not None:
+        args.extend(["-X", method])
+    if json is not None:
+        args.extend(["--json", jsonpkg.dumps(json)])
+    if data is not None:
+        args.extend(["--data-raw", data])
+    if token is not None:
+        args.extend(["--oauth2-bearer", token])
+    args.append(url)
+
+    cmd = shlex.join(args)
+    if wait:
+        response = machine.wait_until_succeeds(cmd)
+    else:
+        response = machine.succeed(cmd)
+
+    if expect_json:
+        return jsonpkg.loads(response)
+    else:
+        return response
+
 
 machine.wait_for_unit("multi-user.target")
 
 api_url = "https://reside.localhost/packit/api"
 
-response = machine.succeed(f"curl -sSfk {api_url}/auth/config")
-data = json.loads(response)
-assert data == {
-  "enableAuth": True,
-  "enableBasicLogin": True,
-  "enableGithubLogin": False,
-  "enablePreAuthLogin": False,
+response = curl(machine, f"{api_url}/auth/config")
+assert response == {
+    "enableAuth": True,
+    "enableBasicLogin": True,
+    "enableGithubLogin": False,
+    "enablePreAuthLogin": False,
 }
 
 with subtest("Can login with username and password"):
     machine.succeed(
-      "create-basic-user reside admin@localhost.com password",
-      "grant-role reside admin@localhost.com ADMIN")
+        "create-basic-user reside admin@localhost.com password",
+        "grant-role reside admin@localhost.com ADMIN",
+    )
 
-    payload = quote(json.dumps({ "email": "admin@localhost.com", "password": "password"}))
-    response = machine.succeed(f"curl -sSfk --json {payload} {api_url}/auth/login/basic")
-    token = json.loads(response)["token"]
+    response = curl(
+        machine,
+        f"{api_url}/auth/login/basic",
+        json={"email": "admin@localhost.com", "password": "password"},
+    )
+    token = response["token"]
 
-    response = machine.succeed(f"curl -sSfk --oauth2-bearer {quote(token)} {api_url}/outpack/")
-    data = json.loads(response)
-    assert data["status"] == "success"
+    response = curl(machine, f"{api_url}/outpack", token=token)
+    assert response["status"] == "success"
+
+with subtest("Can login with device flow"):
+    response = curl(machine, f"{api_url}/deviceAuth", method="POST")
+
+    # This is normally done by the user, in the browser.
+    # The token here is inherited from the previous test.
+    curl(
+        machine,
+        f"{api_url}/deviceAuth/validate",
+        token=token,
+        json={"user_code": response["user_code"]},
+        expect_json=False,
+    )
+
+    data = urlencode({
+        "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        "device_code": response["device_code"],
+    })
+    # Usually this would be in a loop, waiting for the user to complete the browser form.
+    # However we do it programatically so it is guaranteed to be ready immediately.
+    response = curl(machine, f"{api_url}/deviceAuth/token", data=data)
+    token = response["access_token"]
+
+    response = curl(machine, f"{api_url}/outpack", token=token)
+    assert response["status"] == "success"
 
 with subtest("Can login with service token"):
-    key = JWK.generate(kty = "RSA")
-    keyset = JWKSet(keys = key)
-    payload = quote(keyset.export(private_keys = False))
-    machine.succeed(f"curl -sSfk http://127.0.0.1:81/jwks.json -X PUT --data-raw {payload}")
+    key = JWK.generate(kty="RSA")
+    keyset = JWKSet(keys=key)
+    curl(
+        machine,
+        "http://127.0.0.1:81/jwks.json",
+        method="PUT",
+        data=keyset.export(private_keys=False),
+        expect_json=False,
+    )
 
     audience = "https://reside.localhost:8443"
     jwt = JWT(
-        header = { "alg": "RS256" },
-        claims = { "iss": "https://token.actions.githubusercontent.com", "aud": audience }
+        header={"alg": "RS256"},
+        claims={"iss": "https://token.actions.githubusercontent.com", "aud": audience},
     )
     jwt.make_signed_token(key)
 
-    payload = quote(json.dumps({ 'token': jwt.serialize() }))
-    response = machine.succeed(f"curl -sSfk --json {payload} {api_url}/auth/login/service")
-    token = json.loads(response)["token"]
-
-    response = machine.succeed(f"curl -sSfk --oauth2-bearer {quote(token)} {api_url}/outpack/")
-    data = json.loads(response)
-    assert data["status"] == "success"
+    response = curl(
+        machine, f"{api_url}/auth/login/service", json={"token": jwt.serialize()}
+    )
+    token = response["token"]
+    response = curl(machine, f"{api_url}/outpack", token=token)
+    assert response["status"] == "success"
 
 # This is a very minimal test, just making sure the orderly.runner API can start.
 with subtest("orderly.runner"):
-    response = machine.wait_until_succeeds("curl -sSfk http://localhost:8240")
-    data = json.loads(response)
-    assert data["status"] == "success"
-    assert "orderly2" in data["data"]
-    assert "orderly.runner" in data["data"]
+    response = curl(machine, "http://localhost:8240", wait=True)
+    assert response["status"] == "success"
+    assert "orderly2" in response["data"]
+    assert "orderly.runner" in response["data"]


### PR DESCRIPTION
Packit needs to be configured with the URL of the page used for activating device flow logins. This is communicated to the client and shown in the console. Without this change, the user gets shown the default `http://localhost:3000/device`.

I've added an integration test for the device flow and cleaned up the test script a little with a helper function `curl`. That function handles all the quoting needed to run stuff in the VM correctly.