### PR TITLE
Use the vimc-robot account to create the pull request.

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -87,6 +87,15 @@ jobs:
             ${{ steps.prepare-message.outputs.body }}
           reviewers: plietar
 
+          # Pull requests created by a GitHub action's GITHUB_TOKEN don't run
+          # actions on them. The workaround is to use a token tied to an
+          # account to do this. We use the vimc-robot account to do this.
+          #
+          # It will push the changes to its own fork and create a pull request
+          # from there.
+          token: ${{ secrets.VIMC_ROBOT_GITHUB_TOKEN }}
+          push-to-fork: vimc-robot/packit-infra
+
       - name: Comment hint
         uses: thollander/actions-comment-pull-request@v3
         if: steps.create-pr.outputs.pull-request-operation == 'created'

--- a/playbooks/updating-packit.md
+++ b/playbooks/updating-packit.md
@@ -35,12 +35,8 @@ should help you identify whether the update is particularly risky.
 This repository contains an integration test that largely mimicks the staging
 and production environments within a virtual machine. The test suite doesn't
 yet cover a lot of behaviour, altough this will hopefully be expanded in the
-future.
-
-A separate GitHub actions workflow should run on the pull request that was
-automatically opened by the update workflow. Unfortunately GitHub doesn't run
-workflows on pull requests opened by other workflows[^workflow-loop]. You can
-make the tests run by closing and re-opening the pull request.
+future. A separate GitHub actions workflow will run on the pull request that
+was automatically opened.
 
 The tests can also be run locally by checking out the pull request and running
 the following command:
@@ -48,9 +44,6 @@ the following command:
 ```sh
 nix flake check -L
 ```
-
-[^workflow-loop]: Presumably, this is to avoid an infinite cycle of a workflow
-    triggering itself.
 
 ## 3. Deploy the pull request to `wpia-packit-dev`
 


### PR DESCRIPTION
Pull request created by an action's default GITHUB_TOKEN do not trigger any further action runs (presumably to avoid cycles). This was affecting the nightly update action, and required manual intervention to get the CI to run.

By using a token that is tied to a specific account we can workaround this. I have created a fork of this repository under vimc-robot/packit-infra and added a PAT that can push to it and create pull requests.